### PR TITLE
packet_iddigitizerv2 decoder modified to deal with multiple ADC boards

### DIFF
--- a/newbasic/oncsBuffer.h
+++ b/newbasic/oncsBuffer.h
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 
-#include <Event/event_io.h>
+#include "event_io.h"
 
 #ifndef __CINT__
 

--- a/newbasic/packet_iddigitizerv2.h
+++ b/newbasic/packet_iddigitizerv2.h
@@ -46,7 +46,7 @@ protected:
   int _nchannels;
   int _is_decoded;
 
-  int array[32][128];
+  int array[32][4*64];
 
 };
 


### PR DESCRIPTION
The XMIT board digests the digitizer board header that comes it way and reformats the fields into its own header. However, it sees data from multiple ADC boards as one contiguous stream, that is, it will NOT strip the board headers of boards past the very first one. 

That makes for a rather convoluted decoder, since now the blobs from board 0 is different in length than the others. In addition, we will eventually have zero-suppressed data, so we cannot rely on just counting channels. All the calculations which board and which channel it is is based exclusively on the MSB tag word, so this will work with zero-suppressed data once we have them. It's still a lot of effort to work around the diminishing return of saving 6 measly header words (out of a packet size of almost 6000 ),  

The other minor change is the include statement in oncsBuffer.h, which still had "<>". 