### PR TITLE
mlp - APIs and a modified dump() function to bring out the per-board clocks, slots, event nrs.

### DIFF
--- a/newbasic/packet_iddigitizerv2.h
+++ b/newbasic/packet_iddigitizerv2.h
@@ -23,13 +23,15 @@ protected:
   int decode ();
 
 
+
   int _evtnr;
   int _detid;
   int _module_address;
   int _clock;
-  int _fem_slot;
-  int _fem_evtnr;
-  int _fem_clock;
+
+  int _fem_slot[4];
+  int _fem_evtnr[4];
+  int _fem_clock[4];
 
   int _nsamples;
   int _nr_modules;


### PR DESCRIPTION
The comment says it - we are dumping the per-board (and make the accessible via API call) values.

```
Packet  21351  5981  0 (Unformatted)    93 (IDDIGITIZERV2)
Evt Nr:      0
Clock:       22672
Nr Modules:  3
Channels:    192
Samples:     31
Det. ID:     0x5555
Mod. Addr:   0x3333
FEM Slot:          16      15      14
FEM Evt nr:         1       1       1
FEM Clock:      22542   22546   22534
Even chksum: 0xff14   calculated:  0xff14 ok
Odd chksum:  0x5bfb   calculated:  0x5bfb ok
```