### PR TITLE
mlp - add the digitizer hitformats for 12 and 16 samples.

### DIFF
--- a/newbasic/A_Event.cc
+++ b/newbasic/A_Event.cc
@@ -641,7 +641,9 @@ Packet *A_Event::makePacket(PHDWORD *pp, const int hitFormat)
       return new Packet_id4scaler(pp);
       break;
 
-    case IDDIGITIZERV2:
+    case IDDIGITIZER_12S:
+    case IDDIGITIZER_16S:
+    case IDDIGITIZER_31S:
       return new Packet_iddigitizerv2(pp);
       break;
 

--- a/newbasic/packetConstants.h
+++ b/newbasic/packetConstants.h
@@ -295,7 +295,11 @@
 #define IDCDEVDESCR         2017
 #define IDSTARSCALER        2098
 
-#define IDDIGITIZERV2       93
+#define IDDIGITIZER_31S     93
+#define IDDIGITIZER_12S     94
+#define IDDIGITIZER_16S     95
+
+
 
 
 // EMC data header and trailer length

--- a/newbasic/packet_iddigitizerv2.cc
+++ b/newbasic/packet_iddigitizerv2.cc
@@ -63,18 +63,27 @@ int Packet_iddigitizerv2::decode ()
 
   int *SubeventData = (int *) findPacketDataStart(packet); 
 
-  //  _nsamples    = (SubeventData[0] >> 24 ) & 0xff;
+  switch ( getHitFormat() )
+    {
+    case IDDIGITIZER_12S:
+      _nsamples    = 12;
+      break;
+
+    case IDDIGITIZER_16S:
+      _nsamples    = 16;
+      break;
+
+    default:
+      _nsamples    = 31;
+      break;
+    }
+
 
   _evtnr           =  SubeventData[0]  & 0xffff;
   _detid           =  SubeventData[2]  & 0xffff;
 
   _module_address  = SubeventData[3] & 0xffff;
   _clock           = SubeventData[4] & 0xffff;
-  _nsamples      = SubeventData[5] & 0xff;
-
-  // if we are looking at older data without the nr_samples encoded,
-  // they are 31 samples wide. 
-  if ( _nsamples == 0xff) _nsamples = 31;
 
   _fem_slot[0]        = SubeventData[6] & 0xffff;
   _fem_evtnr[0]       = SubeventData[7] & 0xffff;

--- a/newbasic/packet_mnemonic.cc
+++ b/newbasic/packet_mnemonic.cc
@@ -20,7 +20,9 @@ const char *get_mnemonic (const int structure, const int format)
     case(ID4EVT): return "ID4EVT";
     case(ID2SUP): return "ID2SUP";
     case(ID4SCALER): return "ID4SCALER";
-    case(IDDIGITIZERV2): return "IDDIGITIZERV2";
+    case(IDDIGITIZER_12S): return "IDDIGITIZER_12S";
+    case(IDDIGITIZER_16S): return "IDDIGITIZER_16S";
+    case(IDDIGITIZER_31S): return "IDDIGITIZER_31S";
     case(IDHAMMOND): return "IDHAMMOND";
     case(IDSAM): return "IDSAM";
     case(IDDCFEM): return "IDDCFEM";


### PR DESCRIPTION
I added the digitizer hitformats to indicate that the packet contains 12 and 16 samples. 

This  is the poor man's version of going about it, but it's the best I can do. It is still possible to configure the readout one way and state the wrong number of samples in the hitformat, rather than to embed the information (and also allow an arbitrary number of samples, not just 12,16,31) in 5 spare bits in the payload somewhere, but this is not my code.

Now we have 
IDDIGITIZER_31S     93
IDDIGITIZER_12S     94
IDDIGITIZER_16S     95

