### PR TITLE
mlp -- a rather serious bug in the digitizer decoder.

### DIFF
--- a/newbasic/packet_iddigitizerv2.cc
+++ b/newbasic/packet_iddigitizerv2.cc
@@ -138,7 +138,7 @@ int Packet_iddigitizerv2::decode ()
       // so for module 0, we substract 0, module 1, 6 and module 2, 12, ...
       int tag = realtag - 6*module;
       
-      int value = k[index] & 0xffff;
+      int value = k[index] & 0x3fff;
 
       //no quite done... we now have to cut out the extra header words
       // so if we have one of those 6 words, we skip


### PR DESCRIPTION
I brought out 16, rather than 14 bits from the value, and caused
the values to oscillate with higher bits set.