### PR TITLE
mlp - added hitformats for the MM3 chip and real-time clock

### DIFF
--- a/newbasic/oncsSubConstants.h
+++ b/newbasic/oncsSubConstants.h
@@ -77,6 +77,10 @@
 #define IDTPCFEEV1     97
 #define IDMVTXV0       98
 
+#define IDTPCFEEV2     99
+
+#define IDVMM3V1      102
+
 
 // the "level 0", meaning the raw untreated FEM data 
 

--- a/newbasic/packetConstants.h
+++ b/newbasic/packetConstants.h
@@ -47,6 +47,7 @@
 #define ID4EVT    IDOFFSET + 6 
 #define ID2SUP    IDOFFSET + 7 
 #define ID4SCALER IDOFFSET + 8 
+#define IDRTCLOCK IDOFFSET + 9 
 
 // ---------------------------------------------------------------------
 // the next methods are for the hammond/g-2 board.


### PR DESCRIPTION
I also added an early version of the sPHENIX TPC data format, in addition to the (not yet implemented, btw) MM3 chip and the real-time clock data format.   