### PR TITLE
build dictionaries only for root5

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -235,6 +235,13 @@ noinst_HEADERS = \
 
 pkginclude_HEADERS = $(allheaders) $(msgheaders)
 
+if ! MAKEROOT6
+  ROOT5_MSGDICTS = \
+    msg_dict.C
+ROOT5_EVENTDICTS = \
+    event_dict.C
+endif
+
 CLEANFILES = \
   ioselect.h \
   event_dict.C \
@@ -300,7 +307,10 @@ libmessage_la_SOURCES = \
   strnstr.cc 
 
 
-libEvent_la_SOURCES =  event_dict.C 
+libEvent_la_SOURCES =  \
+  $(ROOT5_EVENTDICTS)
+#event_dict.C 
+
 libEvent_la_LIBADD = libNoRootEvent.la libRootmessage.la  @ROOTGLIBS@  -lz @LZOLIB@
 
 libNoRootEvent_la_SOURCES = $(allsources) 
@@ -332,7 +342,9 @@ endif
 if LINUX
 
 libRootmessage_la_SOURCES = \
-  msg_dict.C
+  $(ROOT5_MSGDICTS)
+
+#  msg_dict.C
 
 msg_dict.C : \
   msg_control.h \

--- a/newbasic/configure.ac
+++ b/newbasic/configure.ac
@@ -73,6 +73,7 @@ if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
 
 LZOLIB="-llzo2"
 AC_SUBST(LZOLIB)

--- a/newbasic/eventLinkDef.h
+++ b/newbasic/eventLinkDef.h
@@ -1,17 +1,13 @@
 #ifdef __CINT__
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
 #pragma link C++ class Packet-!;
 #pragma link C++ class testEventiterator-!;
 #pragma link C++ class fileEventiterator-!;
 #pragma link C++ class listEventiterator-!;
 #pragma link C++ class oncsEventiterator-!;
 #pragma link C++ class rcdaqEventiterator-!;
-#pragma link C++ class Eventiterator;
-#pragma link C++ class Event;
+#pragma link C++ class Eventiterator-!;
+#pragma link C++ class Event-!;
 
 
 #endif

--- a/newbasic/msgLinkDef.h
+++ b/newbasic/msgLinkDef.h
@@ -1,9 +1,5 @@
 #ifdef __CINT__
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
 #pragma link C++ class date_filter_msg_buffer-!;
 #pragma link C++ class filter_msg_buffer-!;
 #pragma link C++ class msg_buffer-!;

--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -15,7 +15,7 @@ pkginclude_HEADERS = $(include_HEADERS)
 
 noinst_HEADERS = $(LINKFILE)
 
-BUILT_SOURCES = pmonitor_dict.C
+#BUILT_SOURCES = pmonitor_dict.C
 
 #ROOTCINT =  $(ROOTSYS)/bin/rootcint 
 ROOTCINT =  rootcint 
@@ -26,16 +26,20 @@ lib_LTLIBRARIES = libpmonitor.la
 
 LDFLAGS = -Wl,--no-as-needed 
 
+if ! MAKEROOT6
+  ROOT5_DICTS = \
+    pmonitor_dict.C
+endif
 
 libpmonitor_la_SOURCES = \
+  $(ROOT5_DICTS) \
   pmonitor.cc \
   pmongui.cc \
   pmonitor.h \
   pmonstate.h \
   pmondisplay.h \
   pmongui.h \
-  pMutex.cc \
-  pmonitor_dict.C
+  pMutex.cc
 
 
 if FROG

--- a/pmonitor/configure.ac
+++ b/pmonitor/configure.ac
@@ -31,6 +31,7 @@ if test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 fi
+AM_CONDITIONAL([MAKEROOT6],[test `root-config --version | gawk '{print $1>=6.?"1":"0"}'` = 1])
 
 AC_CHECK_FILE( $OFFLINE_MAIN/include/FROG.h,have_frog=yes, have_frog=no)
 AC_MSG_RESULT([$have_frog])


### PR DESCRIPTION
Non I/O dictionaries are only needed for ROOT5, actually ROOT6 behaves badly when those dictionaries are added, ROOT6 gets the class info from their include files - basically all classes are available on the cmd line by default