### PR TITLE
install also EvtStructures.h

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -25,6 +25,7 @@ installedheaders = \
   EventTypes.h \
   Eventiterator.h \
   EvtConstants.h \
+  EvtStructures.h \
   BufferConstants.h \
   phenixTypes.h \
   testEventiterator.h \


### PR DESCRIPTION
that one needs to be installed - it crashes downstream packages which include oEvent.h