### PR TITLE
Added the ability to selectively stop canvas update threads 

### DIFF
--- a/pmonitor/pmonitor.h
+++ b/pmonitor/pmonitor.h
@@ -46,6 +46,6 @@ void phelp();
 
 void pupdate(TVirtualPad * pad, const unsigned int refresh = 5);
 //void start_update(TVirtualPad * pad);
-void pend_update();
+void pend_update(TVirtualPad * pad = 0);
 
 #endif /* __PMONITOR__ */


### PR DESCRIPTION
I added the ability to selectively stop update threads that
have been started with pupdate(canvas_name). One can stop
all of them by pend_update() as before, or issue
pend_update(canvas_name) to stop only that thread.