### PR TITLE
cumulative update - BXRAW interface, Jin's fix merged, ...

### DIFF
--- a/newbasic/oncsSub_idtpcfeev2.cc
+++ b/newbasic/oncsSub_idtpcfeev2.cc
@@ -217,7 +217,9 @@ int oncsSub_idtpcfeev2::decode ()
 		      }
 		    else
 		      {
-			tpc_sample x = { bx_count + s - HEADER_LENGTH + rollover_offset - first_bx, fee_data[fee].at(index + s ) };
+			tpc_sample x = { bx_count + s -HEADER_LENGTH + rollover_offset - first_bx,
+					 bx_count,
+					 fee_data[fee].at(index + s ) };
 			fee_samples[fee][fee_channel].push_back(x);
 		      }
 		  }
@@ -280,11 +282,15 @@ int oncsSub_idtpcfeev2::iValue(const int fee, const int ch, const int sample, co
        sample < 0 || sample >= fee_samples[fee][ch].size() ) return 0;
 
 
-  if ( strcmp(what,"BX") == 0 )
-  {
-    return fee_samples[fee][ch].at(sample).bx_time;
-  }
-
+  if ( strcmp(what,"BXRAW") == 0 )
+    {
+      return fee_samples[fee][ch].at(sample).bx_time_raw;
+    }
+  else if ( strcmp(what,"BX") == 0 )
+    {
+      return fee_samples[fee][ch].at(sample).bx_time;
+    }
+  return 0;
 }
 
 int oncsSub_idtpcfeev2::iValue(const int fee, const int ch, const char *what)

--- a/newbasic/oncsSub_idtpcfeev2.h
+++ b/newbasic/oncsSub_idtpcfeev2.h
@@ -43,6 +43,7 @@ protected:
   typedef struct
   {
     unsigned int bx_time;
+    unsigned int bx_time_raw;
     unsigned short adc;
   } tpc_sample;
   


### PR DESCRIPTION
This update implements a new interface iValue(fee, channel, sample, "BXRAW" ) that returns the unmodified BX value from the record in question. The similar "BX" defines the earliest BX as time=0 (and so starts at 0), AND implements a rollover correction. This cannot be used for the streaming event pool as we need to combine same-BX records from different RCDAQ events. 
Also merged Jin's intermediate fix in here. 