### PR TITLE
register keyword outlawed for c++17

### DIFF
--- a/newbasic/simpleRandom.cc
+++ b/newbasic/simpleRandom.cc
@@ -136,7 +136,7 @@ simpleRandom::xMD5Final(byte bdigest[16], struct xMD5Context *ctx)
 void
 simpleRandom::xMD5Transform(word32 buf[4], word32 const in[16])
 {
-        register word32 a, b, c, d;
+        word32 a, b, c, d;
 
         a = buf[0];
         b = buf[1];


### PR DESCRIPTION
This PR removes the last register keyword. It is obsolete and clang 9 does not want to compile this anymore with -std=c++17