### PR TITLE
getting rid of compiler warnings

### DIFF
--- a/newbasic/BufferConstants.h
+++ b/newbasic/BufferConstants.h
@@ -2,16 +2,16 @@
 #define __BUFFER_CONSTANTS_H
 
 /* the header length values */ 
-#define BUFFERHEADERLENGTH 4
-#define EOBLENGTH 4
-#define BUFFERSIZE (1024*1024)
+#define BUFFERHEADERLENGTH 4U
+#define EOBLENGTH 4U
+#define BUFFERSIZE (1024U*1024U)
 
-#define BUFFERMARKER      0xffffffc0
-#define ONCSBUFFERMARKER  0xffffc0c0
-#define GZBUFFERMARKER    0xfffffafe
-#define LZO1XBUFFERMARKER 0xffffbbfe
+#define BUFFERMARKER      0xffffffc0U
+#define ONCSBUFFERMARKER  0xffffc0c0U
+#define GZBUFFERMARKER    0xfffffafeU
+#define LZO1XBUFFERMARKER 0xffffbbfeU
 
-#define BUFFERBLOCKSIZE 8192
+#define BUFFERBLOCKSIZE 8192U
 
 
 

--- a/newbasic/EvtConstants.h
+++ b/newbasic/EvtConstants.h
@@ -2,7 +2,7 @@
 #define __EVT_CONSTANTS_H
 
 /* the header length values */ 
-#define EVTHEADERLENGTH 8
+#define EVTHEADERLENGTH 8U
 
 
 #endif

--- a/newbasic/changehitformat.cc
+++ b/newbasic/changehitformat.cc
@@ -50,7 +50,7 @@ public:
 
    // info & debug utils
    
-   int change_hf(const int oldhf, const int newhf);
+   int change_hf(const unsigned int oldhf, const unsigned int newhf);
 
 
 };
@@ -66,14 +66,14 @@ X_Event::X_Event (int *data)
 X_Event::~X_Event ()
 { }
 
-int X_Event::change_hf (const int oldhf, const int newhf)
+int X_Event::change_hf (const unsigned int oldhf, const unsigned int newhf)
 {
   
   int i = 0;
   PHDWORD *fp;
   PHDWORD *pp;
   
-  while ( fp = framelist[i++] )
+  while ( (fp = framelist[i++]) )
     {
       pp = findFramePacketIndex (fp, 0);
       while (  pp !=  ptrFailure) 
@@ -126,7 +126,6 @@ main(int argc, char *argv[])
 
   int eventnr = 0;
 
-  extern char *optarg;
   extern int optind;
 
   PHDWORD  *buffer;
@@ -186,14 +185,14 @@ main(int argc, char *argv[])
 
 
   int paircount = 0;
-  int idold[1000];
-  int idnew[1000];
+  unsigned int idold[1000];
+  unsigned int idnew[1000];
 
   int argind = 0;
   while ( optind +2 + argind +1 < argc) 
     {
-      !sscanf(argv[optind +2 + argind]    , "%d", &idold[paircount]); 
-      !sscanf(argv[optind +2 + argind + 1], "%d", &idnew[paircount]); 
+      sscanf(argv[optind +2 + argind]    , "%ud", &idold[paircount]); 
+      sscanf(argv[optind +2 + argind + 1], "%ud", &idnew[paircount]); 
       COUT << "changing  " << idold[paircount] << " -> " << idnew[paircount] << std::endl;
       argind+=2;
       paircount++;

--- a/newbasic/changeid.cc
+++ b/newbasic/changeid.cc
@@ -75,7 +75,7 @@ int X_Event::change_id (const int oldid, const int newid)
   PHDWORD *pp;
   UINT ids = oldid;
   
-  while ( fp = framelist[i++] )
+  while ( (fp = framelist[i++]) )
     {
       if ( ( pp = findFramePacketId (fp, ids) ) !=  ptrFailure) 
 	{
@@ -122,7 +122,6 @@ main(int argc, char *argv[])
 
   int eventnr = 0;
 
-  extern char *optarg;
   extern int optind;
 
   PHDWORD  *buffer;
@@ -187,8 +186,8 @@ main(int argc, char *argv[])
   int argind = 0;
   while ( optind +2 + argind +1 < argc) 
     {
-      !sscanf(argv[optind +2 + argind]    , "%d", &idold[paircount]); 
-      !sscanf(argv[optind +2 + argind + 1], "%d", &idnew[paircount]); 
+      sscanf(argv[optind +2 + argind]    , "%d", &idold[paircount]); 
+      sscanf(argv[optind +2 + argind + 1], "%d", &idnew[paircount]); 
       COUT << "changing  " << idold[paircount] << " -> " << idnew[paircount] << std::endl;
       argind+=2;
       paircount++;

--- a/newbasic/decoding_routines.cc
+++ b/newbasic/decoding_routines.cc
@@ -64,7 +64,7 @@ int decode_id2evt( int iarr[]
 
   short *sptr = SubeventData;
  
-  int nrl;
+  int nrl=0;
   for (i=0; i < dlength ; i++)
     {
       /*

--- a/newbasic/fileEventiterator.cc
+++ b/newbasic/fileEventiterator.cc
@@ -172,7 +172,7 @@ int fileEventiterator::read_next_buffer()
   // set the pointer to char to the destination buffer
   char *cp = (char *) initialbuffer;
 
-  int xc;
+  unsigned int xc;
 
 
   // this while loop implements the skipping of 8k records until

--- a/newbasic/oBuffer.cc
+++ b/newbasic/oBuffer.cc
@@ -134,7 +134,7 @@ int oBuffer::prepare_next()
 
 
 // ---------------------------------------------------------
-int oBuffer::nextEvent( const int evtsize, const int etype, const int evtseq)
+int oBuffer::nextEvent( const unsigned int evtsize, const int etype, const int evtseq)
 {
 
   if (current_event) delete current_event;
@@ -167,13 +167,13 @@ int oBuffer::nextEvent( const int evtsize, const int etype, const int evtseq)
   return 0;
 }
 // ---------------------------------------------------------
-int oBuffer::addRawEvent( int *data)
+int oBuffer::addRawEvent( unsigned int *data)
 {
   
   if ( ! good_object) return -1;
   int wstatus;
 
-  int nw = data[0];
+  unsigned int nw = data[0];
 
   if ( nw > left-EOBLENGTH)
     {
@@ -329,7 +329,7 @@ int oBuffer::writeout()
       unsigned int ip =0;
       char *cp = (char *) bptr;
 
-      while (ip<bptr->Length)
+      while (ip < bptr->Length)
 	{
 	  write ( fd, cp, BUFFERBLOCKSIZE);
 	  cp += BUFFERBLOCKSIZE;

--- a/newbasic/oBuffer.cc
+++ b/newbasic/oBuffer.cc
@@ -331,7 +331,12 @@ int oBuffer::writeout()
 
       while (ip < bptr->Length)
 	{
-	  write ( fd, cp, BUFFERBLOCKSIZE);
+	  int n = write ( fd, cp, BUFFERBLOCKSIZE);
+	  if ( n != BUFFERBLOCKSIZE)
+	    {
+	      std::cout << " could not write output, bytes written: " << n << std::endl;
+	      return 0;
+	    }
 	  cp += BUFFERBLOCKSIZE;
 	  ip+=BUFFERBLOCKSIZE;
 	}

--- a/newbasic/oBuffer.h
+++ b/newbasic/oBuffer.h
@@ -47,12 +47,12 @@ public:
   virtual  ~oBuffer();
 
   //  this creates a new event on the next address
-  virtual int nextEvent( const int evtsize, const int etype =0, const int evtseq =0);
+  virtual int nextEvent( const unsigned int evtsize, const int etype =0, const int evtseq =0);
 
 
   // frame and packet adding
 
-  virtual int addRawEvent(int *);
+  virtual int addRawEvent(unsigned int *);
 
   virtual int addEvent(Event *);
 
@@ -92,7 +92,7 @@ protected:
 #endif
   typedef struct 
   { 
-    int Length;
+    unsigned int Length;
     int ID;
     int Bufseq;
     int Runnr;

--- a/newbasic/ogzBuffer.cc
+++ b/newbasic/ogzBuffer.cc
@@ -54,7 +54,12 @@ int ogzBuffer::writeout()
 
   while (ip<outputarray[0])
     {
-      write ( fd, cp, BUFFERBLOCKSIZE);
+	  int n = write ( fd, cp, BUFFERBLOCKSIZE);
+	  if ( n != BUFFERBLOCKSIZE)
+	    {
+	      std::cout << " could not write output, bytes written: " << n << std::endl;
+	      return 0;
+	    }
       cp += BUFFERBLOCKSIZE;
       ip += BUFFERBLOCKSIZE;
     }

--- a/newbasic/olzoBuffer.cc
+++ b/newbasic/olzoBuffer.cc
@@ -82,7 +82,13 @@ int olzoBuffer::writeout()
 
   while (ip<outputarray[0])
     {
-      write ( fd, cp, BUFFERBLOCKSIZE);
+	  int n = write ( fd, cp, BUFFERBLOCKSIZE);
+	  if ( n != BUFFERBLOCKSIZE)
+	    {
+	      std::cout << " could not write output, bytes written: " << n << std::endl;
+	      return 0;
+	    }
+
       cp += BUFFERBLOCKSIZE;
       ip += BUFFERBLOCKSIZE;
     }

--- a/newbasic/oncsBuffer.cc
+++ b/newbasic/oncsBuffer.cc
@@ -31,7 +31,7 @@ oncsBuffer::oncsBuffer (PHDWORD *array , const PHDWORD length )
 int oncsBuffer::buffer_swap()
 {
 
-  int i;
+  unsigned int i;
   unsigned int evtindex, sevtindex;
   oncsevtdata_ptr evtptr;
   subevtdata_ptr sevtptr;

--- a/newbasic/oncsEvent.h
+++ b/newbasic/oncsEvent.h
@@ -3,7 +3,7 @@
 
 #include "Event.h"
 #include "phenixTypes.h"
-#include "oncsEvtConstants.h"
+#include "EvtConstants.h"
 #include "oncsEvtStructures.h"
 #include <map>
 

--- a/newbasic/oncsEventiterator.cc
+++ b/newbasic/oncsEventiterator.cc
@@ -134,7 +134,7 @@ int oncsEventiterator::read_next_buffer()
   // set the pointer to char to the destination buffer
   char *cp = (char *) initialbuffer;
 
-  int xc;
+  unsigned int xc;
 
   // read the first record
   xc = read ( fd, cp, 8192);

--- a/newbasic/oncsEventiterator.h
+++ b/newbasic/oncsEventiterator.h
@@ -27,7 +27,7 @@ private:
   
   char * thefilename;
   int fd;
-  int initialbuffer[BUFFERSIZE];
+  unsigned int initialbuffer[BUFFERSIZE];
   int *bp;
   int allocatedsize;
 

--- a/newbasic/oncsEvtConstants.h
+++ b/newbasic/oncsEvtConstants.h
@@ -2,7 +2,7 @@
 #define __ONCSEVT_CONSTANTS_H
 
 /* the header length values */ 
-#define EVTHEADERLENGTH 8
+//#define EVTHEADERLENGTH 8
 
 
 #endif

--- a/newbasic/oncsEvtStructures.h
+++ b/newbasic/oncsEvtStructures.h
@@ -1,7 +1,7 @@
 #ifndef __ONCSEVT_STRUCTURES_H
 #define __ONCSEVT_STRUCTURES_H
 
-#include "oncsEvtConstants.h"
+#include "EvtConstants.h"
 
 typedef struct oncsevt_data
  {

--- a/newbasic/oncsSubConstants.h
+++ b/newbasic/oncsSubConstants.h
@@ -10,7 +10,7 @@
 #define MAX_OUTLENGTH 80000
 
 // the header length value
-#define SEVTHEADERLENGTH 4
+#define SEVTHEADERLENGTH 4U
 
 
 

--- a/newbasic/oncsSub_idbspetdata.cc
+++ b/newbasic/oncsSub_idbspetdata.cc
@@ -31,7 +31,6 @@ int *oncsSub_idbspetdata::decode ( int *nwout)
 
   unsigned long long timebits, coarse_timestamp, fine_timestamp;
   unsigned int word1, word2;
-  unsigned int clockID;
 
   int i;
   unsigned int *SubeventData = (unsigned int *) &SubeventHdr->data;
@@ -64,7 +63,6 @@ int *oncsSub_idbspetdata::decode ( int *nwout)
 	{
 
 	  word1 = SubeventData[2*i+1];
-	  clockID = (word1 >> 30) & 0x3; 
 
 	  p[k] = (( word1 >> 24) & 0x3f); // block id
 	  if (  p[k] ==3)  p[k]=2;

--- a/newbasic/oncsSub_idcaenv1742.cc
+++ b/newbasic/oncsSub_idcaenv1742.cc
@@ -24,7 +24,6 @@ int *oncsSub_idcaenv1742::decode ( int *nwout)
   int *p;
 
 
-  int i,channel;
   int *SubeventData = &SubeventHdr->data;
 
 
@@ -76,7 +75,7 @@ int *oncsSub_idcaenv1742::decode ( int *nwout)
 
   for ( group_nr=0; group_nr < 4; group_nr++)
     {
-      int pos;
+      int pos = 0;
 
       if  ( (group_mask >> group_nr) &1) // we have that group present
 	{

--- a/newbasic/oncsSub_idcstr.cc
+++ b/newbasic/oncsSub_idcstr.cc
@@ -35,8 +35,6 @@ void oncsSub_idcstr::dump ( OSTREAM &os)
   int n;
   if ( ! sarray ) decode ( &n);
 
-  int i = 1;
-  int c;
 
   os.write( (const char *) sarray, allocated_length);
 

--- a/newbasic/oncsSub_iddreamv0.cc
+++ b/newbasic/oncsSub_iddreamv0.cc
@@ -268,7 +268,7 @@ int *oncsSub_iddreamv0::decode ( int *nwout)
 int oncsSub_iddreamv0::decode_payload ( unsigned short *d, const int size) 
 {
 
-  FEU_decoded_data *fd;
+  FEU_decoded_data *fd = 0;
 
   int nwpacket_index = 0;  // this is supposed to point to the network packet start
   int index = 0;
@@ -280,7 +280,7 @@ int oncsSub_iddreamv0::decode_payload ( unsigned short *d, const int size)
   int event_id;
   int time_stamp;
 
-  int sample_id;
+  int sample_id =-1;
   int fine_tstp; 
   int old_eventid = -1;
 
@@ -450,8 +450,6 @@ int oncsSub_iddreamv0::decode_dream( FEU_decoded_data *fd, unsigned short *d, co
   unsigned long long cell_id;
   unsigned long long trigger_id;
 
-  unsigned int cmnl;
-  unsigned int cmnh;
   unsigned int dream_id;
 
   
@@ -464,9 +462,6 @@ int oncsSub_iddreamv0::decode_dream( FEU_decoded_data *fd, unsigned short *d, co
   trigger_id |= (d[1] & 0xfff) << 12;
   trigger_id |= (d[2] & 0xfff);
 
-  cmnl = d[68] & 0xfff;
-  cmnh = d[69] & 0xfff;
-  
   cell_id =  (d[70] & 0xfff) << 24;
   cell_id |= (d[71] & 0xfff) << 12;
   cell_id |= (d[72] & 0xfff);

--- a/newbasic/oncsSub_iddrs4v1.cc
+++ b/newbasic/oncsSub_iddrs4v1.cc
@@ -21,8 +21,6 @@ oncsSub_iddrs4v1::~oncsSub_iddrs4v1()
 int *oncsSub_iddrs4v1::decode ( int *nwout)
 {
 
-  int dlength = ( getLength()-4) - getPadding();
-
 
   samples = SubeventHdr->data & 0xffff;
   enabled_channelmask = (SubeventHdr->data >> 16) & 0xf;

--- a/newbasic/oncsSub_idfnalmwpc.cc
+++ b/newbasic/oncsSub_idfnalmwpc.cc
@@ -377,7 +377,7 @@ void  oncsSub_idfnalmwpc::dump ( OSTREAM& os )
   decode (0);
   identify(os);
 
-  int i, j, k, l;
+  int j, k, l;
 
 
   os << " Date         " << iValue(0, "MONTH") 
@@ -427,9 +427,10 @@ void  oncsSub_idfnalmwpc::dump ( OSTREAM& os )
 oncsSub_idfnalmwpc::~oncsSub_idfnalmwpc()
 {
   
-  int i, j, k, l;
+
+  int l;
+  unsigned int i,k;
   TDCEvent *te;
-  TDC_hit *th;
 
   for ( k = 0; k< TDCEventVector.size() ; k++)
     {

--- a/newbasic/oncsSub_idfnalmwpcv2.cc
+++ b/newbasic/oncsSub_idfnalmwpcv2.cc
@@ -163,7 +163,6 @@ int *oncsSub_idfnalmwpcv2::decode ( int *nwout)
 	       << " wrong TDC index " << tdcindex << " pos= " << pos-1 << endl;
 	}
 
-      int EventStatus = s[pos+2];
 
       //cout << __FILE__ << " " <<  __LINE__ << " pos, value " << setw(4) << pos << " " << hex << s[pos] << dec << endl;
       int SpillTriggerCount = s[pos+3]<<16;  // we get a 32bit value
@@ -383,7 +382,7 @@ void  oncsSub_idfnalmwpcv2::dump ( OSTREAM& os )
   decode (0);
   identify(os);
 
-  int i, j, k, l;
+  int j, k, l;
 
 
   os << " Date         " << iValue(0, "MONTH") 

--- a/newbasic/oncsSub_idmvtxv0.cc
+++ b/newbasic/oncsSub_idmvtxv0.cc
@@ -186,8 +186,8 @@ int *oncsSub_idmvtxv0::decode ()
         int status = 0;
         int ibyte_endofdata = -1;
         int the_region = -1;
-        unsigned int address;
-        unsigned int encoder_id;
+        unsigned int address=0;
+        unsigned int encoder_id = 0;
         for (unsigned int ibyte = 0; ibyte < ruchn_stream[ruchn].size(); ibyte++)
         {
             b = ruchn_stream[ruchn].at(ibyte);
@@ -568,7 +568,7 @@ void oncsSub_idmvtxv0::gdump(const int i, OSTREAM& out) const
 {
 
     int *SubeventData = &SubeventHdr->data;
-    int j,l;
+    unsigned int j,l;
     identify(out);
 
     int current_offset;

--- a/newbasic/oncsSub_idmvtxv1.cc
+++ b/newbasic/oncsSub_idmvtxv1.cc
@@ -615,7 +615,9 @@ void oncsSub_idmvtxv1::gdump(const int i, OSTREAM& out) const
 {
 
     int *SubeventData = &SubeventHdr->data;
-    int j,l;
+    unsigned int j;
+    int l;
+
     identify(out);
 
     int current_offset;

--- a/newbasic/oncsSub_idsrs_v01.cc
+++ b/newbasic/oncsSub_idsrs_v01.cc
@@ -269,7 +269,7 @@ int oncsSub_idsrs_v01::iValue(const int ich, const int tsample, const int hybrid
 
 	  //cout << __LINE__ << "  " << __FILE__ << " tsample " << tsample << "  " << (*it)->rowdata.size() << endl;
 
-	  if ( (*it)->rowdata.size()  < tsample +1) return 0;
+	  if ( (*it)->rowdata.size()  < (unsigned int)(tsample +1)) return 0;
 
 	  report *r  = (*it)->rowdata[tsample];
 	  return r->adc[ich];

--- a/newbasic/oncsSub_idtpcfeev1.cc
+++ b/newbasic/oncsSub_idtpcfeev1.cc
@@ -27,7 +27,7 @@ oncsSub_idtpcfeev1::~oncsSub_idtpcfeev1()
 }
 
 
-#define HEADER_LENGTH 7
+#define HEADER_LENGTH 7U
 
 int oncsSub_idtpcfeev1::decode ()
 {
@@ -36,13 +36,11 @@ int oncsSub_idtpcfeev1::decode ()
   _is_decoded = 1;
 
   int recv_length = getLength() - SEVTHEADERLENGTH - getPadding();
-  int *k;
 
   _nsamples    = 0;
   _nchannels   = 32;
 
   uint32_t *buffer = ( uint32_t *)  &SubeventHdr->data;
-  unsigned int marker_key = buffer[0];
   unsigned int payload_len = buffer[1] & 0xffff;
 
   _bx_count = ((buffer[4] & 0xffff) << 4) | (buffer[5] & 0xf);  
@@ -50,10 +48,8 @@ int oncsSub_idtpcfeev1::decode ()
   for (int i = 0; i < recv_length; i += (payload_len+1))
     {
       payload_len = (buffer[i+1] & 0xffff);
-      unsigned int  packet_type = buffer[i+2] & 0xffff;
       unsigned int channel     = buffer[i+3] & 0x1f;
       unsigned int  sampa_addr  = (buffer[i+3] >> 5) & 0xf;
-      int bx_count    = ((buffer[i+4] & 0xffff) << 4) | (buffer[i+5] & 0xf);
       
       if ( sampa_addr > 1)
 	{
@@ -70,7 +66,7 @@ int oncsSub_idtpcfeev1::decode ()
 	{
 	  _nchips = sampa_addr;
 	}
-      for  ( int s = 0; s < payload_len - HEADER_LENGTH; s++)
+      for  ( unsigned int s = 0; s < payload_len - HEADER_LENGTH; s++)
 	{
 	  array[sampa_addr*32 + channel][s] =  buffer[i+s+HEADER_LENGTH] & 0xffff;
 	}
@@ -87,17 +83,17 @@ int oncsSub_idtpcfeev1::iValue(const int ch, const int sample)
 {
      decode();
 
-     if ( sample >= _nsamples || sample < 0 
-	  || ch >= _nchips * _nchannels || ch < 0 ) return 0;
+     if ( sample >= (int) _nsamples || sample < 0 
+	   || ch >= (int) (_nchips * _nchannels) || ch < 0 ) return 0;
      
   return array[ch][sample];
 
 }
 int oncsSub_idtpcfeev1::iValue(const int chip, const int ch, const int sample)
 {
-     if ( sample >= _nsamples || sample < 0 
-	  || chip >= _nchips || chip < 0  
-	  || ch >= _nchannels || ch < 0 ) return 0;
+  if ( sample >= (int)_nsamples || sample < 0 
+       || chip >= (int) _nchips || chip < 0  
+       || ch >= (int) _nchannels || ch < 0 ) return 0;
      
      return iValue(chip*32 + ch, sample);
 

--- a/newbasic/oncsSub_idtpcfeev1.h
+++ b/newbasic/oncsSub_idtpcfeev1.h
@@ -25,13 +25,13 @@ protected:
 
   int _broken;
   
-  int _is_decoded;
-  int _nchips;
-  int _nchannels;
-  int _nsamples;
-  int _bx_count;
+  unsigned int _is_decoded;
+  unsigned int _nchips;
+  unsigned int _nchannels;
+  unsigned int _nsamples;
+  unsigned int _bx_count;
   
-  int array[64][1002]; 
+  unsigned int array[64][1002]; 
 
 };
 

--- a/newbasic/oncsSub_idtpcfeev2.cc
+++ b/newbasic/oncsSub_idtpcfeev2.cc
@@ -271,7 +271,7 @@ int oncsSub_idtpcfeev2::iValue(const int fee, const int ch, const int sample)
   decode();
   if ( fee > MAX_FEECOUNT ||
        ch < 0 || ch >= MAX_FEECHANNELS ||
-       sample < 0 || sample >= fee_samples[fee][ch].size() ) return 0;
+       sample < 0 || (unsigned int) sample >= fee_samples[fee][ch].size() ) return 0;
   
   //  if ( sample >= fee_samples[fee][ch].size() ) return 0;
   return fee_samples[fee][ch].at(sample).adc;
@@ -284,7 +284,7 @@ int oncsSub_idtpcfeev2::iValue(const int fee, const int ch, const int sample, co
 
   if ( fee > MAX_FEECOUNT ||
        ch < 0 || ch >= MAX_FEECHANNELS ||
-       sample < 0 || sample >= fee_samples[fee][ch].size() ) return 0;
+       sample < 0 || (unsigned int) sample >= fee_samples[fee][ch].size() ) return 0;
 
 
   if ( strcmp(what,"BXRAW") == 0 )

--- a/newbasic/oncsSub_iduppetdata.cc
+++ b/newbasic/oncsSub_iduppetdata.cc
@@ -43,8 +43,6 @@ int *oncsSub_iduppetdata::decode ( int *nwout)
 {
   int *p;
 
-  unsigned long long fine_timestamp;
-
 
   int i;
 
@@ -98,7 +96,6 @@ int *oncsSub_iduppetdata::decode ( int *nwout)
       x64 |= y;
 
 
-      fine_timestamp = (x64 >> 44) & 0x3f;
       unsigned long long t = x64 & 0xfffffffffffL;
       unsigned int crystalid = ( x64 >> 52) & 0x1f;
       unsigned int block = ( x64 >> 57) & 0x1f;

--- a/newbasic/oncsSub_iduppetdata_v104.cc
+++ b/newbasic/oncsSub_iduppetdata_v104.cc
@@ -46,7 +46,6 @@ int *oncsSub_iduppetdata_v104::decode ( int *nwout)
 {
   int *p;
 
-  unsigned long long fine_timestamp;
 
 
   int i;
@@ -107,7 +106,6 @@ int *oncsSub_iduppetdata_v104::decode ( int *nwout)
       y =  ntohs( sdata[i]);
       x64 |= y;
 
-      fine_timestamp = (x64 >> 46) & 0x3f;
       unsigned long long t = x64 & 0x3fffffffffffL;
       unsigned int crystalid = ( x64 >> 52) & 0x1f;
       unsigned int block = ( x64 >> 57) & 0x1f;

--- a/newbasic/oncsSubevent.cc
+++ b/newbasic/oncsSubevent.cc
@@ -419,7 +419,8 @@ void oncsSubevent_w4::gdump(const int i, OSTREAM& out) const
       return;
     }
 
-  int j,l;
+  unsigned int j;
+  int l;
   identify(out);
   
   switch (i)
@@ -480,7 +481,9 @@ void oncsSubevent_w2::gdump(const int i, OSTREAM& out) const
       return;
     }
 
-  int j,l;
+  unsigned int j;
+  int l;
+
   identify(out);
 
   switch (i)
@@ -540,7 +543,10 @@ void oncsSubevent_w1::gdump(const int i, OSTREAM& out) const
       return;
     }
 
-  int j,l;
+  unsigned int j;
+  int l;
+
+
   char cstring[20];
   char *c;
   identify(out);

--- a/newbasic/packet_hbd_fpga.cc
+++ b/newbasic/packet_hbd_fpga.cc
@@ -110,13 +110,12 @@ int *Packet_hbd_fpga::decode ( int *nwout)
       while ( (k[pos] & 0xF0002000) ==  0x40002000 )  // we have a first adc
 	{
 	  int adc          =  ( k[pos] & 0xfff);
-	  int clockphase   = (( k[pos] >>12 ) & 0x1);
 	  int f_channr     = (( k[pos] >>16 ) & 0x3f);
 	  int f_modnr      = (( k[pos] >>22 ) & 0x3);
 	  int slot = 48*HBD_NSAMPLES*f_modnr + HBD_NSAMPLES*f_channr ; 
 	  //std::cout <<  pos << "  " << std::hex << k[pos] << std::dec 
 	  //	    << "   " << f_modnr << "  " << f_channr  << "  "
-	  //	    << firstadc  << "  "<< clockphase  << "  "<< adc <<  "  " << slot << std::endl;
+	  //	    << firstadc    << "  "<< adc <<  "  " << slot << std::endl;
 	  iarr[slot++] = adc;
 	  pos++;
 	  while ( (k[pos] & 0xF0002000) ==  0x40000000 )  // the remaining ones
@@ -130,10 +129,9 @@ int *Packet_hbd_fpga::decode ( int *nwout)
 		  break;
 		}
 	      adc        =  ( k[pos] & 0xfff);  
-	      clockphase = (( k[pos] >>12 ) & 0x1);
 	      // std::cout <<  pos << "  " << std::hex << k[pos] << std::dec 
 	      //		<< "   " << f_modnr << "  " << f_channr  << "  "
-	      //		<< firstadc  << "  "<< clockphase  << "  "<< adc <<  "  " << slot << std::endl;
+	      //		<< firstadc  << "  "<< adc <<  "  " << slot << std::endl;
 	      iarr[slot++] = adc;
 	      pos++;
 	    }

--- a/newbasic/packet_idcdevdescr.cc
+++ b/newbasic/packet_idcdevdescr.cc
@@ -33,7 +33,7 @@ double Packet_idcdevdescr::dValue(const int ich, const char *what)
     {
       namedVector *x = *it;
       //      std::cout << what  << " x " << x->values.size() << std::endl;
-      if ( ich < 0 || ich >= x->values.size()) return 0;
+      if ( ich < 0 || (unsigned int) ich >= x->values.size()) return 0;
       return  (x->values)[ich];
 
     }

--- a/newbasic/packet_starscaler.cc
+++ b/newbasic/packet_starscaler.cc
@@ -29,7 +29,7 @@ int  *Packet_starscaler::decode ( int *nwout)
   s_vector[0] = 0;
   int *m = (int *) findPacketDataStart(packet);
 
-  unsigned int i;
+  int i;
   for ( i = 0; i < s_vectorlength; i++)
     {
       int l = i*2;

--- a/newbasic/packet_starscaler.h
+++ b/newbasic/packet_starscaler.h
@@ -31,7 +31,7 @@ protected:
 
   virtual int  *decode (int *);
   long long *s_vector;
-  unsigned int s_vectorlength;
+  int s_vectorlength;
 
 #if !defined(SunOS) && !defined(OSF1)
   std::map <int, int> smap;

--- a/newbasic/prdfBuffer.cc
+++ b/newbasic/prdfBuffer.cc
@@ -47,7 +47,7 @@ prdfBuffer::~prdfBuffer()
 int prdfBuffer::buffer_swap()
 {
  
-  int i;
+  unsigned int i;
   unsigned int evtindex, frameindex;
   evtdata_ptr evtptr;
   PHDWORD *frameptr;

--- a/newbasic/prdfcheck.cc
+++ b/newbasic/prdfcheck.cc
@@ -33,7 +33,6 @@ main(int argc, char *argv[])
 
   int needs_swap = 0;
   int length;
-  int bufseq;
   int ip;
 
   int total_read = 0;
@@ -49,20 +48,20 @@ main(int argc, char *argv[])
 
 
       if ( buffer[1] == BUFFERMARKER || 
-	   buffer::i4swap(buffer[1]) == BUFFERMARKER || 
-	   buffer[1] == (int) ONCSBUFFERMARKER || 
-	   buffer::i4swap(buffer[1]) == (int) ONCSBUFFERMARKER ||
-	   buffer[1] == (int) GZBUFFERMARKER || 
-	   buffer::i4swap(buffer[1]) == (int) GZBUFFERMARKER ||
-	   buffer[1] == (int) LZO1XBUFFERMARKER || 
-	   buffer::i4swap(buffer[1]) == (int) LZO1XBUFFERMARKER )
+	   buffer::u4swap(buffer[1]) == BUFFERMARKER || 
+	   buffer[1] == ONCSBUFFERMARKER || 
+	   buffer::u4swap(buffer[1]) == ONCSBUFFERMARKER ||
+	   buffer[1] == GZBUFFERMARKER || 
+	   buffer::u4swap(buffer[1]) ==  GZBUFFERMARKER ||
+	   buffer[1] == LZO1XBUFFERMARKER || 
+	   buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER )
 	{
 
 
-	  if ( buffer::i4swap(buffer[1]) == BUFFERMARKER || 
-	       buffer::i4swap(buffer[1]) == (int) ONCSBUFFERMARKER ||
-	       buffer::i4swap(buffer[1]) == (int) GZBUFFERMARKER ||
-	       buffer::i4swap(buffer[1]) == (int) LZO1XBUFFERMARKER )
+	  if ( buffer::u4swap(buffer[1]) == BUFFERMARKER || 
+	       buffer::u4swap(buffer[1]) == ONCSBUFFERMARKER ||
+	       buffer::u4swap(buffer[1]) == GZBUFFERMARKER ||
+	       buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER )
 	    {
 	      needs_swap = 1;
 	    }
@@ -70,12 +69,10 @@ main(int argc, char *argv[])
 	  if (needs_swap)
 	    {
 	      length = buffer::i4swap(buffer[0]);
-	      bufseq = buffer::i4swap(buffer[2]);
 	    }
 	  else
 	    {
 	      length = buffer[0];
-	      bufseq = buffer[2];
 	    }
 
 	  if ( needs_swap ) 
@@ -94,13 +91,13 @@ main(int argc, char *argv[])
 	    }
 
 	  if ( buffer[1] == BUFFERMARKER || 
-	       buffer::i4swap(buffer[1]) == BUFFERMARKER ) std::cout << "Uncomp. Marker" << std::endl;
- 	  else if ( buffer[1] == (int) ONCSBUFFERMARKER || 
-		    buffer::i4swap(buffer[1]) == (int) ONCSBUFFERMARKER ) std::cout << "sPHENIX Marker" << std::endl;
- 	  else if ( buffer[1] == (int) GZBUFFERMARKER || 
-		    buffer::i4swap(buffer[1]) == (int) GZBUFFERMARKER ) std::cout << "GZIP Marker" << std::endl;
-	  else if ( buffer[1] == (int) LZO1XBUFFERMARKER || 
-		    buffer::i4swap(buffer[1]) == (int) LZO1XBUFFERMARKER ) 
+	       buffer::u4swap(buffer[1]) == BUFFERMARKER ) std::cout << "Uncomp. Marker" << std::endl;
+ 	  else if ( buffer[1] == ONCSBUFFERMARKER || 
+		    buffer::u4swap(buffer[1]) == ONCSBUFFERMARKER ) std::cout << "sPHENIX Marker" << std::endl;
+ 	  else if ( buffer[1] == GZBUFFERMARKER || 
+		    buffer::u4swap(buffer[1]) == GZBUFFERMARKER ) std::cout << "GZIP Marker" << std::endl;
+	  else if ( buffer[1] == LZO1XBUFFERMARKER || 
+		    buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER ) 
 	    {
 	      std::cout << "LZO Marker ";
 	      std::cout << " Or.length: " << buffer[3];
@@ -146,7 +143,7 @@ main(int argc, char *argv[])
 	  if (needs_swap)
 	    {
 	      std::cout << "found a non-buffer start..."<< total_read 
-			<< " length = " << buffer::i4swap(buffer[0]) << " marker = " << std::hex << buffer::i4swap(buffer[1]) << std::dec ;
+			<< " length = " << buffer::u4swap(buffer[0]) << " marker = " << std::hex << buffer::i4swap(buffer[1]) << std::dec ;
 	    }
 	  else
 	    {
@@ -156,9 +153,9 @@ main(int argc, char *argv[])
 
 	  int skipped = 0;
 	  while (  buffer[1] != BUFFERMARKER &&
-	   buffer::i4swap(buffer[1]) != BUFFERMARKER &&
-	   buffer[1] != (int) GZBUFFERMARKER && 
-	   buffer::i4swap(buffer[1]) != (int) GZBUFFERMARKER )
+	   buffer::u4swap(buffer[1]) != BUFFERMARKER &&
+	   buffer[1] != GZBUFFERMARKER && 
+	   buffer::u4swap(buffer[1]) != GZBUFFERMARKER )
 	    {
 	      xc = read ( fd, (char *)buffer, 8192);
 	      if ( xc < 8192 ) 

--- a/newbasic/prdfsplit.cc
+++ b/newbasic/prdfsplit.cc
@@ -25,19 +25,19 @@ void exitmsg()
 // valid buffer marker, or 1 for a buffer that 
 // doesn't need swapping, -1 for one that does need swapping
  
-int check_buffermarker ( const int bm)
+int check_buffermarker ( const unsigned int bm)
 {
   
   if ( bm == BUFFERMARKER || 
-       bm == (int) GZBUFFERMARKER || 
-       bm == (int) LZO1XBUFFERMARKER )
+       bm == GZBUFFERMARKER || 
+       bm == LZO1XBUFFERMARKER )
     {
       return 1;
     }
   
-  else if ( buffer::i4swap(bm) == BUFFERMARKER || 
-	    buffer::i4swap(bm) == (int) GZBUFFERMARKER ||
-	    buffer::i4swap(bm) == (int) LZO1XBUFFERMARKER )
+  else if ( buffer::u4swap(bm) == BUFFERMARKER || 
+	    buffer::u4swap(bm) == GZBUFFERMARKER ||
+	    buffer::u4swap(bm) == LZO1XBUFFERMARKER )
     {
       return -1;
     }
@@ -76,9 +76,7 @@ int  main(int argc, char *argv[])
     }
 
 
-  int needs_swap = 0;
   int length;
-  int bufseq;
   int ip;
 
   int total_read = 0;
@@ -86,8 +84,6 @@ int  main(int argc, char *argv[])
   int xc;
 
   int current_fdnr = 0;
-  int nwritten;
-
 
   xc = read ( fd, (char *)buffer, 8192);
   //  total_read++;
@@ -101,22 +97,23 @@ int  main(int argc, char *argv[])
 	{
 
 	  //	  std::cout << " new buffer " << buffer[0] << std::endl;
-	  needs_swap = 0;
 	  
 	  if ( markerstatus == -1)
 	    {
-	      needs_swap = 1;
 	      length = buffer::i4swap(buffer[0]);
-	      bufseq = buffer::i4swap(buffer[2]);
 	    }
 	  else
 	    {
 	      length = buffer[0];
-	      bufseq = buffer[2];
 	    }
 
 
-	  nwritten = write (fdout[current_fdnr], buffer, 8192);
+	  int nwritten = write (fdout[current_fdnr], buffer, 8192);
+	  if ( nwritten < 8192)
+	    {
+		  std::cout << " could not write output " << total_read << std::endl;
+		  exit(1);
+	    }
 
 	  while ( ip < length)
 	    {

--- a/newbasic/rcdaqEventiterator.cc
+++ b/newbasic/rcdaqEventiterator.cc
@@ -160,7 +160,6 @@ Event * rcdaqEventiterator::getNextEvent()
 
 int rcdaqEventiterator::read_next_buffer()
 {
-  int ip = 0;
   if (bptr) 
     {
       delete bptr;

--- a/newbasic/simpleRandom.cc
+++ b/newbasic/simpleRandom.cc
@@ -44,7 +44,7 @@ simpleRandom::xMD5Init(struct xMD5Context *ctx)
  * of bytes.
  */
 void
-simpleRandom::xMD5Update(struct xMD5Context *ctx, byte const *buf, int len)
+simpleRandom::xMD5Update(struct xMD5Context *ctx, byte const *buf, unsigned int len)
 {
         word32 t;
 
@@ -55,7 +55,7 @@ simpleRandom::xMD5Update(struct xMD5Context *ctx, byte const *buf, int len)
                 ctx->bytes[1]++;        /* Carry from low to high */
 
         t = 64 - (t & 0x3f);    /* Space available in ctx->in (at least 1) */
-        if ((unsigned)t > len) {
+        if ( t > len) {
                 bcopy(buf, (byte *)ctx->in + 64 - (unsigned)t, len);
                 return;
         }
@@ -218,7 +218,7 @@ simpleRandom::xMD5Transform(word32 buf[4], word32 const in[16])
 }
 
 
-void simpleRandom::MD5(byte *dest, const byte *orig, int len)
+void simpleRandom::MD5(byte *dest, const byte *orig, unsigned int len)
 {
         struct xMD5Context context;
 

--- a/newbasic/simpleRandom.cc
+++ b/newbasic/simpleRandom.cc
@@ -112,7 +112,7 @@ simpleRandom::xMD5Final(byte bdigest[16], struct xMD5Context *ctx)
 
         byteSwap(ctx->buf, 4);
         bcopy(ctx->buf, bdigest, 16);
-        bzero(ctx,sizeof(ctx));
+        bzero(ctx,sizeof(*ctx));
 }
 
 

--- a/newbasic/simpleRandom.h
+++ b/newbasic/simpleRandom.h
@@ -75,10 +75,10 @@ private:
   
   void byteSwap(word32 *buf, unsigned words);
   void xMD5Init(struct xMD5Context *ctx);
-  void xMD5Update(struct xMD5Context *ctx, byte const *buf, int len);
+  void xMD5Update(struct xMD5Context *ctx, byte const *buf, unsigned int len);
   void xMD5Final(byte digest[16], struct xMD5Context *ctx);
   void xMD5Transform(word32 buf[4], word32 const in[16]);
-  void MD5(byte *dest, const byte *orig, int len);
+  void MD5(byte *dest, const byte *orig, unsigned int len);
   void load_seed();
 
   unsigned int digest[4];


### PR DESCRIPTION
The event libraries are among the oldest parts of our software base, and had accumulated a good amount of compiler warnings with newer compilers. This commit should reduce that number to close to zero. It may take one more Jenkins report with the superset of all compilers. 