### PR TITLE
typedef byte needs to be in simpleRandom namespace for rootcling

### DIFF
--- a/newbasic/simpleRandom.h
+++ b/newbasic/simpleRandom.h
@@ -55,7 +55,6 @@
 
 
 typedef unsigned int word32;
-typedef unsigned char byte;
 
 struct xMD5Context {
         word32 buf[4];
@@ -72,7 +71,8 @@ public:
   float rnd(int low, int high);
 
 private:
-  
+  typedef unsigned char byte;
+
   void byteSwap(word32 *buf, unsigned words);
   void xMD5Init(struct xMD5Context *ctx);
   void xMD5Update(struct xMD5Context *ctx, byte const *buf, unsigned int len);


### PR DESCRIPTION
rootcling has problems with the typedef unsigned char byte; it collides with a class byte. To fix this the typedef needs to be in the simpleRandom namespace, moving the typedef into the class fixes this ambiguity for cling