### PR TITLE
mlp -- removing the apparently offending compiler flag again.

### DIFF
--- a/pmonitor/configure.ac
+++ b/pmonitor/configure.ac
@@ -18,7 +18,7 @@ AC_PROG_INSTALL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -std=c++11"
+  CXXFLAGS="$CXXFLAGS -Wall"
 fi
 
 ROOTLIBS=`root-config --libs`


### PR DESCRIPTION
had added c++11... back where we were before.