### PR TITLE
install oncsSubevent.h, replace <> by quotes for local include

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -23,6 +23,7 @@ installedheaders = \
   oncsEvtStructures.h \
   oncsStructures.h \
   oncsSubConstants.h \
+  oncsSubevent.h \
   EventTypes.h \
   Eventiterator.h \
   EvtConstants.h \

--- a/newbasic/oncsSubevent.h
+++ b/newbasic/oncsSubevent.h
@@ -6,9 +6,10 @@
 #include "packet.h"
 #include "decoding_routines.h"
 #include "oncsStructures.h"
+#include "oncsSubConstants.h"
+
 #include <stddef.h>
 
-#include <oncsSubConstants.h>
 
 #ifndef __CINT__
 class WINDOWSEXPORT oncsSubevent : public Packet {


### PR DESCRIPTION
This PR adds installation of oncsSubevent.h which is pulled in by the ospBuffer.h. If using the installed includes #include <oncsSubConstants.h> does not work. It needs #include "oncsSubConstants.h" to locate it.

