### PR TITLE
Fix clang warnings

### DIFF
--- a/newbasic/Cframe.C
+++ b/newbasic/Cframe.C
@@ -245,8 +245,8 @@ PTRACCESSFUNCTIONPTR_arr CONSTANT findFrameErrorStartV = {0, &findFrameErrorStar
 PTRACCESSFUNCTIONPTR_arr CONSTANT findFrameAlignBlockV = {0, &findFrameAlignBlockV1};
 PTRACCESSFUNCTIONPTR_arr CONSTANT findFrameHistoryStartV = {0, &findFrameHistoryStartV1};
 
-CHECKFUNCTIONPTR_arr  CONSTANT validFrameHdrV = {0, &validFrameHdrV1};
-CHECKFUNCTIONPTR_arr  CONSTANT emptyFrameV = {0, &emptyFrameV1};
+//CHECKFUNCTIONPTR_arr  CONSTANT validFrameHdrV = {0, &validFrameHdrV1};
+//CHECKFUNCTIONPTR_arr  CONSTANT emptyFrameV = {0, &emptyFrameV1};
 
 MODIFYFUNCTIONPTR_arr CONSTANT orFrameStatusV = {0, &orFrameStatusV1};
 MODIFYFUNCTIONPTR_arr CONSTANT setFramePaddingV = {0, &setFramePaddingV1};

--- a/newbasic/Cpacket.C
+++ b/newbasic/Cpacket.C
@@ -294,8 +294,7 @@ PTRACCESSPFUNCPTR_arr CONSTANT findPacketErrorStartV = {NULLPTRACCESSPFUNC,
 							&findPacketV1ErrorStart};
 PTRACCESSPFUNCPTR_arr CONSTANT findPacketDebugStartV = {NULLPTRACCESSPFUNC, 
 							&findPacketV1DebugStart};
-PTRACCESSPFUNCPTR_arr CONSTANT findPacketDataStartV = {NULLPTRACCESSPFUNC, 
-						       &findPacketV1DataStart};
+//PTRACCESSPFUNCPTR_arr CONSTANT findPacketDataStartV = {NULLPTRACCESSPFUNC, &findPacketV1DataStart};
 PTRACCESSPFUNCPTR_arr CONSTANT findPacketDataEndV = {NULLPTRACCESSPFUNC, &findPacketV1DataEnd};
 PTRACCESSPFUNCPTR_arr CONSTANT findPacketDataDescrV = {NULLPTRACCESSPFUNC, 
 						       &findPacketV1DataDescr};

--- a/newbasic/caen_correction.cc
+++ b/newbasic/caen_correction.cc
@@ -1,9 +1,9 @@
+#include "caen_correction.h"
+#include "packet.h"
+
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-
-#include "caen_correction.h"
-#include "Event/packet.h"
 
 using namespace std;
 

--- a/newbasic/caen_correction.h
+++ b/newbasic/caen_correction.h
@@ -2,9 +2,10 @@
 #ifndef __CAEN_CORRECTION_H__
 #define __CAEN_CORRECTION_H__
 
+#include <string>
+
 class Packet;
 class caen_correction {
-#include <string>
 
 public:
 

--- a/newbasic/configure.ac
+++ b/newbasic/configure.ac
@@ -56,7 +56,7 @@ AC_PROG_INSTALL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-overloaded-virtual -Wno-class-memaccess -Wno-unknown-warning-option"
 fi
 
 AC_HEADER_STDC

--- a/newbasic/ddump.cc
+++ b/newbasic/ddump.cc
@@ -142,7 +142,7 @@ int rangeParser ( const std::string string, std::vector<int> &selection)
   std::vector<std::string>::const_iterator it, itr;
   std::vector<std::string> strs,r;
 
-  std::vector<int>::const_iterator vit;
+//  std::vector<int>::const_iterator vit;
   int low,high,i;
   boost::split(strs,string, boost::is_any_of(","));
 

--- a/newbasic/dpipe.cc
+++ b/newbasic/dpipe.cc
@@ -149,7 +149,7 @@ int
 main(int argc, char *argv[])
 {
   int c;
-  int status;
+  int status = 0;
 
   int sourcetype =DFILE;
   int destinationtype = ETPOOL;

--- a/newbasic/oncsSub_idsrs_v01.cc
+++ b/newbasic/oncsSub_idsrs_v01.cc
@@ -258,7 +258,7 @@ int oncsSub_idsrs_v01::iValue(const int ich, const int tsample, const int hybrid
   if ( nhybrids == 0 ) decoded_data1 = decode(&data1_length);
  
   std::vector<hybriddata*>::iterator it;
-  std::vector<report *>::iterator reportit;
+//  std::vector<report *>::iterator reportit;
 
   for ( it = hybridlist.begin(); it != hybridlist.end(); ++it)
     {

--- a/pmonitor/configure.ac
+++ b/pmonitor/configure.ac
@@ -18,7 +18,7 @@ AC_PROG_INSTALL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-vexing-parse"
 fi
 
 ROOTLIBS=`root-config --libs`

--- a/pmonitor/pmonstate.h
+++ b/pmonitor/pmonstate.h
@@ -51,7 +51,7 @@ class pmonstate
   char * Name;
   int idflag;
 
-  Eventiterator * it;
+//  Eventiterator * it;
 
  public:
   pmonstate()


### PR DESCRIPTION
This PR fixes the clang warnings (unused variables commented out). I added -Werror to the compiler flags and suppressed some warnings I did not feel comfortable to fix in the configure.ac