### PR TITLE
no root 6 dictionary needed (also no pcm file)

### DIFF
--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -58,11 +58,6 @@ libpmonitor_la_LIBADD = \
 
 endif
 
-pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-     pmonitor_dict_rdict.pcm
-
-
 pmonitor_dict.C: pmonitor.h pmonstate.h  $(LINKFILE)
 	$(ROOTCINT) -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 


### PR DESCRIPTION
This PR removes the pcm file from the Makefile.am. These files are only needed by ROOT6 for persistent classes which is not the case here.