### PR TITLE
suppress compiler warnings when using -Wextra

### DIFF
--- a/newbasic/configure.ac
+++ b/newbasic/configure.ac
@@ -56,7 +56,7 @@ AC_PROG_INSTALL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-overloaded-virtual -Wno-class-memaccess -Wno-unknown-warning-option"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-overloaded-virtual -Wno-class-memaccess -Wno-unknown-warning-option -Wno-unused-parameter -Wno-type-limits -Wno-unused-but-set-parameter"
 fi
 
 AC_HEADER_STDC

--- a/pmonitor/configure.ac
+++ b/pmonitor/configure.ac
@@ -18,7 +18,7 @@ AC_PROG_INSTALL
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-vexing-parse"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-vexing-parse -Wno-unused-parameter"
 fi
 
 ROOTLIBS=`root-config --libs`


### PR DESCRIPTION
This PR adds compiler flags which suppress warnings caused by using -Wextra. For newbasic it is:
-Wno-unused-parameter -Wno-type-limits -Wno-unused-but-set-parameter
for pmonitor it is
-Wno-unused-parameter