### PR TITLE
ifdef guard fix

### DIFF
--- a/newbasic/oncsSubConstants.h
+++ b/newbasic/oncsSubConstants.h
@@ -1,5 +1,5 @@
-#ifndef __SUBEVT_CONSTANTS_H
-#define __SUBEVT_CONSTANTS_H
+#ifndef __ONCS_SUBEVT_CONSTANTS_H
+#define __ONCS_SUBEVT_CONSTANTS_H
 
 /* the enum types for dump style */
 #define EVT_DECIMAL     1

--- a/newbasic/packetConstants.h
+++ b/newbasic/packetConstants.h
@@ -303,6 +303,8 @@
 #define IDDIGITIZER_12S     94
 #define IDDIGITIZER_16S     95
 
+#define IDDIGITIZER_CTRL     2099
+
 
 
 

--- a/newbasic/packet_w124.cc
+++ b/newbasic/packet_w124.cc
@@ -128,7 +128,7 @@ void Packet_w2::gdump(const int i, OSTREAM& out) const
 
   if ( i == EVT_RAW)
     {
-      fwrite(packetData, sizeof(short), 2*(getDataLength() - getPadding()), stdout);
+      fwrite(packetData, sizeof(short), getDataLength(), stdout);
       return;
     }
 
@@ -162,9 +162,9 @@ void Packet_w2::gdump(const int i, OSTREAM& out) const
 	  for (l=0;l<8;l++)
 	    {
 	      out << std::hex << SETW(4) << packetData[j++] << " " ;
-	      if (j>=2*getDataLength() ) break;
+	      if (j>=getDataLength() ) break;
 	    }
-	  if (j>=2*getDataLength() ) break;
+	  if (j>=getDataLength() ) break;
 	  out << std::dec <<  std::endl;
 	}
       out << std::dec <<  std::endl;
@@ -178,9 +178,9 @@ void Packet_w2::gdump(const int i, OSTREAM& out) const
 	  for (l=0;l<8;l++)
 	    {
 	      out << SETW(6) << packetData[j++] << " ";
-	      if (j>=2*getDataLength()) break;
+	      if (j>=getDataLength()) break;
 	    }
-	  if (j>=2*getDataLength() ) break;
+	  if (j>=getDataLength() ) break;
 	  out << std::endl;
 	}
       out << std::dec <<  std::endl;
@@ -201,7 +201,7 @@ void Packet_w1::gdump(const int i, OSTREAM& out) const
 
   if ( i == EVT_RAW)
     {
-      fwrite(packetData, sizeof(char), 4*(getDataLength() - getPadding()), stdout);
+      fwrite(packetData, sizeof(char), getDataLength(), stdout);
       return;
     }
 
@@ -231,7 +231,7 @@ void Packet_w1::gdump(const int i, OSTREAM& out) const
 	  out << std::dec << SETW(5) << j << " |  ";
 	  for (l=0;l<16;l++)
 	    {
-	      if (j < 4*(getDataLength()) ) 
+	      if (j < getDataLength() ) 
 		{
 		  *c++ = packetData[j];
 		  out << std::hex << SETW(2) << packetData[j++] << " ";
@@ -244,7 +244,7 @@ void Packet_w1::gdump(const int i, OSTREAM& out) const
 	    }
 	  *c = 0;
 	  out << "  | " << cstring;
-	  if (j >= 4*getDataLength() ) break;
+	  if (j >= getDataLength() ) break;
 	  out << std::endl;
 	}
       break;
@@ -256,7 +256,7 @@ void Packet_w1::gdump(const int i, OSTREAM& out) const
 	  out << std::dec << SETW(5) << j << " |  ";
 	  for (l=0;l<12;l++)
 	    {
-	      if (j < 4*getDataLength() ) 
+	      if (j < getDataLength() ) 
 		{
 		  *c++ = packetData[j];
 		  out << std::hex << SETW(4) << packetData[j++] << " ";
@@ -269,7 +269,7 @@ void Packet_w1::gdump(const int i, OSTREAM& out) const
 	    }
 	  *c = 0;
 	  out << "  | " << cstring;
-	  if (j >= 4*getDataLength() ) break;
+	  if (j >= getDataLength() ) break;
 	  out << std::endl;
 	}
       break;

--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -19,7 +19,7 @@ noinst_HEADERS = $(LINKFILE)
 #ROOTCINT =  $(ROOTSYS)/bin/rootcint 
 ROOTCINT =  rootcint 
 
-AM_CPPFLAGS =  -I$(includedir) -I$(ONLINE_MAIN)/include -I@ROOTINC@
+AM_CPPFLAGS =  -I$(includedir) -I$(ONLINE_MAIN)/include -I@ROOTCFLAGS@
 
 lib_LTLIBRARIES = libpmonitor.la
 

--- a/pmonitor/configure.ac
+++ b/pmonitor/configure.ac
@@ -23,8 +23,10 @@ fi
 
 ROOTLIBS=`root-config --libs`
 ROOTINC=`root-config --incdir`
+ROOTCFLAGS=`root-config --cflags`
 AC_SUBST(ROOTLIBS)
 AC_SUBST(ROOTINC)
+AC_SUBST(ROOTCFLAGS)
 
 dnl test for root 6
 if test `root-config --version | awk '{print $1=6.?"1":"0"}'` = 1; then


### PR DESCRIPTION
switched to the root-config method to get at compiler flags.
fixed an ifdef guard in a header file that clashed with another package.