### PR TITLE
the rdict.pcm files should not be needed

### DIFF
--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -58,10 +58,6 @@ libpmonitor_la_LIBADD = \
 
 endif
 
-pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-   pmonitor_Dict_rdict.pcm
-
 pmonitor_Dict.C: pmonitor.h pmonstate.h  $(LINKFILE)
 	$(ROOTCINT) -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 


### PR DESCRIPTION
The rdict.pcm file depends on the _dict.C file which then needs rootcint which barfs here. I don't think (hope) the pcm file is not needed