### PR TITLE
rootcint does not like cflags

### DIFF
--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -63,7 +63,7 @@ nobase_dist_pcm_DATA = \
    pmonitor_Dict_rdict.pcm
 
 pmonitor_Dict.C: pmonitor.h pmonstate.h  $(LINKFILE)
-	$(ROOTCINT) -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+	$(ROOTCINT) -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) -I$(includedir) $^
 
 bin_SCRIPTS = writePmonProject.pl
 


### PR DESCRIPTION
This PR fixes running rootcint
[pinkenbu@rcas2601 pmonitor]$ rootcint  -f pmonitor_Dict.C  -noIncludePaths  -inlineInputHeader  -c -I. -I/phenix/u/pinkenbu/workarea/sPHENIX/gitrepov5/online_distribution/pmonitor -I/phenix/u/pinkenbu/workarea/sPHENIX/gitrepov5/install/include  -pthread -std=c++17 -m64 -I/cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/opt/sphenix/core/root-6.24.06/include /phenix/u/pinkenbu/workarea/sPHENIX/gitrepov5/online_distribution/pmonitor/pmonitor.h /phenix/u/pinkenbu/workarea/sPHENIX/gitrepov5/online_distribution/pmonitor/pmonstate.h /phenix/u/pinkenbu/workarea/sPHENIX/gitrepov5/online_distribution/pmonitor/pmonitorLinkDef.h
rootcint: for the   -s option: may not occur within a group!
rootcint: for the   -m option: may not occur within a group!
translated means rootcint misinterprets -std=c++17 as -s and -m64 as -m
leaving out the cflags from root fixes this