### PR TITLE
standalone digitizer readout via the controller

### DIFF
--- a/newbasic/oncsEvent.cc
+++ b/newbasic/oncsEvent.cc
@@ -249,6 +249,11 @@ Packet *oncsEvent::makePacket(PHDWORD *pp, const int hitFormat)
 	oncsSub_idmvtxv0( sevt_ptr );
       break;
 
+    case (IDDIGITIZERV1):
+      return new
+	oncsSub_iddigitizerv1( sevt_ptr );
+      break;
+
     case (IDTPCFEEV1):
       return new
 	oncsSub_idtpcfeev1( sevt_ptr );

--- a/newbasic/oncsSubConstants.h
+++ b/newbasic/oncsSubConstants.h
@@ -71,8 +71,9 @@
 
 #define IDPCONTAINER     89
 
-#define IDFNALMWPC     90
+#define IDFNALMWPC       90
 #define IDFNALMWPCV2     91
+#define IDDIGITIZERV1    92
 
 #define IDTPCFEEV1     97
 #define IDMVTXV0       98

--- a/newbasic/oncs_mnemonic.cc
+++ b/newbasic/oncs_mnemonic.cc
@@ -40,6 +40,7 @@ const char *oncs_get_mnemonic (const int structure, const int format)
     case(IDDRS4V1): return "IDDRS4V1";
     case(IDCAENV1742): return  "IDCAENV1742";
     case(IDMVTXV0): return  "IDMVTXV0";
+    case(IDDIGITIZERV1): return  "IDDIGITIZERV1";
     case(IDTPCFEEV1): return  "IDTPCFEEV1";
     case(IDTPCFEEV2): return "IDTPCFEEV2"; 
     case(IDVMM3V1):return "IDVMM3V1";


### PR DESCRIPTION
This implements (or better, re-activates) the format when we read out directly through the controller, not the DCM2. We kept on building the decoder but had taken it out of the active hitformat dispatch.