### PR TITLE
mlp - replace the obsolete ftime(...) API with clock_gettime().

### DIFF
--- a/newbasic/msg_buffer.cc
+++ b/newbasic/msg_buffer.cc
@@ -171,9 +171,9 @@ void streambuf_add_date (STREAMBUF * sb)
 {
 
   
-  struct timeb tp;
-  ftime(&tp);
-  char *timestr = ctime(&tp.time);
+  struct timespec tp;
+  clock_gettime( CLOCK_REALTIME, &tp);
+  char *timestr = ctime(&tp.tv_sec);
   int length = strlen(timestr);
   
   //  char timestr[128];

--- a/newbasic/msg_buffer.h
+++ b/newbasic/msg_buffer.h
@@ -16,7 +16,7 @@
 #include <cstdarg>
 #include <string>
 #include <ctime>
-#include <sys/timeb.h>
+#include <time.h>
 
 #endif
 


### PR DESCRIPTION
the ftime() call was marked obsolete a while ago. It starts disappearing in newer OS versions. I replaced it with the clock_gettime(...) system call that is part of the POSIX standard now. 