### PR TITLE
mlp - added an API to change the packet id for a packet in memory.

### DIFF
--- a/newbasic/oncsSubevent.cc
+++ b/newbasic/oncsSubevent.cc
@@ -59,6 +59,16 @@ int oncsSubevent::getIdentifier() const
 }
 
 // ----------------------------------------------
+
+int oncsSubevent::setIdentifier(const int newid) 
+{
+   // check that we have short range; we want the parameter to be int
+  if ( newid & 0xffff0000) return -1; 
+  SubeventHdr->sub_id = newid;
+  return 0;
+}
+
+// ----------------------------------------------
 //int oncsSubevent::get_type()
 //{
 //  return SubeventHdr->sub_type;

--- a/newbasic/oncsSubevent.h
+++ b/newbasic/oncsSubevent.h
@@ -36,6 +36,8 @@ public:
   // debugging-type information
   virtual void  identify( OSTREAM& =COUT) const;
 
+  virtual int setIdentifier(const int newid);
+  
   // getting decoded values
   int    iValue(const int);
   int    iValue(const int,const char *);

--- a/newbasic/packet.h
+++ b/newbasic/packet.h
@@ -236,7 +236,8 @@ class  Packet
 
   virtual void identify(std::ostream& os = std::cout) const = 0;
 
-
+  /// set a new packet identifier
+  virtual int	setIdentifier(const int newid) = 0; // Identifier
 
   /// write an indepth identification message to the supplied OSTREAM.
   virtual void fullIdentify(std::ostream& os = std::cout) const 

--- a/newbasic/packet_A.cc
+++ b/newbasic/packet_A.cc
@@ -168,6 +168,16 @@ getPacketDebugLength(packet); }
 int Packet_A::getIdentifier() const { return getPacketId (packet); } 
 
 //------------------------------------------------------ 
+int Packet_A::setIdentifier(const int newid) 
+{
+   // check that we have short range; we want the parameter to be int
+  if ( newid & 0xffff0000) return -1;
+  setPacketId (packet, newid);
+  return 0;
+}
+
+
+//------------------------------------------------------ 
 int Packet_A::getPadding() const { 
 return 
 getPacketPadding(packet); 

--- a/newbasic/packet_A.h
+++ b/newbasic/packet_A.h
@@ -66,6 +66,7 @@ public:
   void  dumpErrorBlock ( OSTREAM& =COUT ) ;
   void  dumpDebugBlock ( OSTREAM& =COUT ) ;
 
+  int   setIdentifier(const int newid);
 
   // getting decoded values
   int    iValue(const int);


### PR DESCRIPTION
I added an API to change the packet id for a packet in memory.
This is useful to combine events from tests into full events.