### PR TITLE
mlp - fixed a potential race condition in the Event object

### DIFF
--- a/newbasic/oncsEvent.cc
+++ b/newbasic/oncsEvent.cc
@@ -134,6 +134,13 @@ int oncsEvent::createMap()
 
   for (i=0; i<datalength; i+=  EventData->data[i])
     {
+      if ( EventData->data[i] <= 0) 
+	{
+	  std::cout << "found 0-length packet" << std::endl;
+	  errorcode =-1;
+	  break;
+	}
+
       // each data[i] is the start of a subevent;
       // we map it on a subevent_ptr
 

--- a/newbasic/oncsSubevent.cc
+++ b/newbasic/oncsSubevent.cc
@@ -385,6 +385,18 @@ float*   oncsSubevent::getFloatArray (int *nwout, const char *what)
 
 // ----------------------------------------------
 
+int oncsSubevent::copyMe(int dest[],  const int maxlength) const
+{
+  
+  if ( getLength() > maxlength )
+    {
+      return 0;
+    }
+
+  memcpy((void *) dest, (void *) SubeventHdr, 4*getLength() );
+  return getLength();
+}
+
 
 
 // now the member functions common to all

--- a/newbasic/oncsSubevent.h
+++ b/newbasic/oncsSubevent.h
@@ -61,6 +61,7 @@ public:
   // pointer or data based handling
   virtual int is_pointer_type() const;
   virtual int convert();
+  virtual int   copyMe(int [],  const int maxlength) const;
 
   int setInternalParameter ( const int p1=0, const int p2=0, const char *what = "") {return 0;};
 


### PR DESCRIPTION
fixed a potential race condition in the Event object
implemented the copy function proper for packet data.

There could be a race condition while traversing the event's data for the packets. We move from packet start to packet start. If in a corrupt event the packet length was 0, we would get into an infinite loop since there was no check. I added that check.

There is a also a rarely-used member function that allows one to copy the packet's data to external memory for various purposes. This was not implemented or all packet types. Done.