### PR TITLE
top-level header changes to satisfy -Werror -Wall -Wextra

### DIFF
--- a/newbasic/Event.h
+++ b/newbasic/Event.h
@@ -75,11 +75,10 @@ public:
   */
 
 
+  virtual void listFrame(  const int /*id*/=0, std::ostream& /*os*/=std::cout) const {};
 
-  virtual void listFrame(  const int id=0, std::ostream& os=std::cout) const {};
-
-  virtual void listHistory(  const int id=0, std::ostream& os=std::cout) const {};
-  virtual void listError(  const int id=0, std::ostream& os=std::cout) const {};
+  virtual void listHistory(  const int /*id*/=0, std::ostream& /*os*/=std::cout) const {};
+  virtual void listError(  const int /*id*/=0, std::ostream& /*os*/=std::cout) const {};
 
   /**
    getFrameEntry will return a particular entry from the frame header which contains
@@ -103,7 +102,7 @@ public:
    Asking for a word beyond the number of such words will return 0.
   */
 
-  virtual unsigned int getFrameEntry(  const char *what, const int id=0, const int index =0) const { return 0; };
+  virtual unsigned int getFrameEntry(  const char * /*what*/, const int /*id*/=0, const int /*index */=0) const { return 0; };
 
 
   // ***** packet handling *****
@@ -119,7 +118,7 @@ public:
    For debugging purposes mostly.
     
   */
-  virtual Packet* getPacket(const int, const int hitFormat)=0;
+  virtual Packet* getPacket(const int, const int /*hitFormat*/)=0;
 
   /**
     getPacketList returns a simple-minded array of pointers
@@ -127,13 +126,13 @@ public:
     of packets returned in the array. The second parameter tells
     the packet how long the array is.
   */
-  virtual int getPacketList(Packet*[], const int length) =0;
+  virtual int getPacketList(Packet*[], const int /*length*/) =0;
 
   /**
    existPacket returns 1 if such a packet exists in the
    event. 0 else.
   */
-  virtual int existPacket (const int packetid)=0;
+  virtual int existPacket (const int /*packetid*/)=0;
 
   // **** event copying *****
   /**
@@ -143,7 +142,7 @@ public:
 
    if what = "RAW" then we just copy the payload data without the event header.
   */
-  virtual int Copy ( int *destination, const unsigned int length, int *nw, const char * what ="" )=0;
+  virtual int Copy ( int *destination, const unsigned int /*length*/, int *nw, const char * /*what */="" )=0;
 
 
   /**
@@ -159,7 +158,7 @@ public:
    the header for fast event selection purposes. This is mainly used by the
    ET system to distribute events based on its properties.
   */
-  virtual unsigned int getTagWord( const int i=0) const { return 0;};
+  virtual unsigned int getTagWord( const int /*i*/ =0) const { return 0;};
 
   virtual int is_pointer_type() const =0;
 

--- a/newbasic/Eventiterator.h
+++ b/newbasic/Eventiterator.h
@@ -38,18 +38,18 @@ public:
   virtual int *getNextEventData() {return 0;};
   virtual int releaseEventData() {return 0;};
 
-  virtual void setBlockingMode(const int mode) {};
+  virtual void setBlockingMode(const int /*mode*/) {};
   virtual int getBlockingMode() const {return 0;};
 
-  virtual void setSelectMode(const int mode) {};
+  virtual void setSelectMode(const int /*mode*/) {};
   virtual int getSelectMode() const {return 0;};
 
-  virtual void setSelectWords(const int i1, const int i2, const int i3, const int i4 ) {};
-  virtual void getSelectWords(int val[]) const {};
+  virtual void setSelectWords(const int , const int , const int , const int  ) {};
+  virtual void getSelectWords(int []) const {};
 
   virtual const char * getCurrentFileName() const { return " "; };
 
-  virtual int  setVerbosity(const int v) { return -1; }; // most iterators don't have the concept
+  virtual int  setVerbosity(const int ) { return -1; }; // most iterators don't have the concept
   virtual int  getVerbosity() const { return -1; };
 
 

--- a/newbasic/caen_correction.cc
+++ b/newbasic/caen_correction.cc
@@ -101,27 +101,31 @@ int caen_correction::init (Packet *p)
 	    }
 	}
 
-      //      // the TR cells
-      // idx = cell;
-      //for ( i = 0; i < 1024; i++)
-      //	{
-      //	  if (chip < 2)	  current_wave[i][chip*8+8] = p->iValue(i,"TR0") - base[idx][chip*9+8];
-      //	  else  current_wave[i][chip*9+8] = p->iValue(i,"TR1") - base[idx][chip*9+8];
-      //	  idx++;
-      //	  if (idx >=1024) idx=0;
-      //	}
+      // Trigger cells;
+      {
+	idx = cell;
+	for ( i = 0; i < 1024; i++)
+	  {
+	    current_wave[i][32+chip] = p->iValue(i,32+chip) - base[idx][chip*9+8];
+	    idx++;
+	    if (idx >=1024) idx=0;
+	  }
+      }
     }
   return 0;
 }
 	  
 float caen_correction::caen_corrected(const int sample, const int channel) const
 {
-  if ( sample < 0 || sample >1023 || channel < 0 || channel > 31) return 0;
+  //if ( sample < 0 || sample >1023 || channel < 0 || channel > 31) return 0;
+  if ( sample < 0 || sample >1023 || channel < 0 || channel > 35) return 0;
   return current_wave[sample][channel];
 }
 
 float caen_correction::caen_time(const int sample, const int channel) const
 {
-  if ( sample < 0 || sample >1023 || channel < 0 || channel > 31) return 0;
-  return current_time[sample][channel/8];
+  //if ( sample < 0 || sample >1023 || channel < 0 || channel > 31) return 0;
+  //return current_time[sample][channel/8];
+  if ( sample < 0 || sample >1023 || channel < 0 || channel > 35) return 0;
+  return current_time[sample][channel < 32 ? channel/8 : channel-32];
 }

--- a/newbasic/oncsSub_idcaenv1742.cc
+++ b/newbasic/oncsSub_idcaenv1742.cc
@@ -151,10 +151,12 @@ int oncsSub_idcaenv1742::iValue(const int sample, const int ch)
 
   if ( decoded_data1 == 0 ) decoded_data1 = decode(&data1_length);
 
-  if ( ch < 0 || ch >= 32 ) return 0;
+  //if ( ch < 0 || ch >= 32 ) return 0;
+  if ( ch < 0 || ch >= 36 ) return 0;
   if ( sample < 0 || sample >= samples ) return 0;
 
-  return decoded_data1[ch*samples + sample];
+  //return decoded_data1[ch*samples + sample];
+  return (ch < 32 ? decoded_data1[ch*samples + sample] : decoded_data2[(ch-32)*samples + sample]);
 
 }
 

--- a/newbasic/packet.h
+++ b/newbasic/packet.h
@@ -56,35 +56,35 @@ class  Packet
 
 
   /// iValue returns the value of a given channel as an int. 
-  virtual int    iValue(const int channel) =0;
+  virtual int    iValue(const int /*channel*/) =0;
 
   /** with the "what" parameter you can decide which aspect 
       of the data you want to see (for devices which have more than one)
   */
-  virtual int    iValue(const int channel, const char * what) =0;
+  virtual int    iValue(const int /*channel*/, const char * /*what*/) =0;
 
   /** we have a few recent devices which have one more dimension 
       (such as card, time sample, channel)
   */
-  virtual int    iValue(const int channel, const int y, const char * what) =0;
+  virtual int    iValue(const int /*channel*/, const int /*y*/, const char * /*what*/) =0;
 
   /** this supports devices which are inherently organized as two-dimensional
       data, such as flash ADC's (channel vs time slice) 
   */
-  virtual int    iValue(const int channel,const int iy) =0;
+  virtual int    iValue(const int /*channel*/,const int /*iy*/) =0;
 
   /** this supports devices  organized as three-dimensional
       data (card vs channel vs time slice ) 
   */
-  virtual int    iValue(const int channel,const int iy, const int iz) =0;
+  virtual int    iValue(const int /*channel*/,const int /*iy*/, const int /*iz*/) =0;
 
   /** this supports devices  organized as three-dimensional
       data (card vs channel vs time slice, with a "what" selection ) 
   */
-  virtual int    iValue(const int channel,const int iy, const int iz, const char *what) =0;
+  virtual int    iValue(const int /*channel*/,const int /*iy*/, const int /*iz*/, const char */*what*/) =0;
 
   /** rValue returns the value of a given channel as a float */
-  virtual float  rValue(const int channel) =0;
+  virtual float  rValue(const int /*channel*/) =0;
 
   /** dValue returns the value of a given channel as a double */
   virtual double  dValue(const int channel) 
@@ -110,25 +110,25 @@ class  Packet
   /** with the "what" parameter you can decide which aspect 
       of the data you want to see (for devices which have more than one)
   */
-  virtual float  rValue(const int channel, const char * what) =0;
+  virtual float  rValue(const int /*channel*/, const char * /*what*/) =0;
 
 
   /** this supports devices which are inherently organized as two-dimensional
       data, such as flash ADC's (channel vs time slice) 
   */
-  virtual float  rValue(const int channel, const int iy) =0;
+  virtual float  rValue(const int /*channel*/, const int /*iy*/) =0;
 
-  virtual void * pValue(const int chan)
+  virtual void * pValue(const int /*channel*/)
   {
     return 0;
   }
 
-  virtual void * pValue(const int chan, const char *what)
+  virtual void * pValue(const int /*channel*/, const char * /*what*/)
   {
     return 0;
   }
 
-  virtual void * pValue(const int chan, const int iy)
+  virtual void * pValue(const int /*chan*/, const int /*iy*/)
   {
     return 0;
   }
@@ -149,24 +149,24 @@ class  Packet
       with the decoded data
   */ 
   virtual int    fillIntArray (int destination[],    // the data go here 
-			       const int length,      // space we have in destination
-			       int * nw,              // words actually used
+			       const int /*length*/,      // space we have in destination
+			       int * /*nw*/,              // words actually used
 			       const char * what="") = 0; // type of data (see above)
 
   ///  fillFloatArray fills an array of floats
   virtual int    fillFloatArray (float destination[],    // the data go here 
-				 const int length,      // space we have in destination
-				 int * nw,              // words actually used
+				 const int /*length*/,      // space we have in destination
+				 int * /*nw*/,              // words actually used
 				 const char * what="") = 0; // type of data (see above)
 
   /** getIntArray and getFloatArray create a new array of the approriate size
       fill it with the decoded values, and return a pointer to the array. 
       nw is the length of the array created. 
   */
-  virtual int*   getIntArray (int * nw,const char * ="") =0;
+  virtual int*   getIntArray (int * /*nw*/,const char * ="") =0;
 
   ///  getFloatArray creates and returns an array of floats
-  virtual float* getFloatArray (int * nw,const char * ="") =0;
+  virtual float* getFloatArray (int * /*nw*/,const char * ="") =0;
 
   
   /// find out what type (pointer- or data based) packet object we have
@@ -237,7 +237,7 @@ class  Packet
   virtual void identify(std::ostream& os = std::cout) const = 0;
 
   /// set a new packet identifier
-  virtual int	setIdentifier(const int newid) = 0; // Identifier
+  virtual int	setIdentifier(const int /*newid*/) = 0; // Identifier
 
   /// write an indepth identification message to the supplied OSTREAM.
   virtual void fullIdentify(std::ostream& os = std::cout) const 
@@ -267,7 +267,7 @@ class  Packet
 
   */
   virtual int getCheckSumStatus() const { return 0;};
-  virtual int   copyMe(int [],  const int maxlength) const { return 0;};
+  virtual int   copyMe(int [],  const int /*maxlength*/) const { return 0;};
 
   virtual int setInternalParameter ( const int p1=0, const int p2=0, const char *what = "") = 0;
 


### PR DESCRIPTION
I found that a function prototype like
   `virtual void listFrame( const int id=0, std::ostream& os=std::cout) const {};`
is flagged when using -Wall -Werror -Wextra complier flags. I changed this in the top-level includes to like
   `virtual void listFrame( const int /*id*/ =0, std::ostream& /*os*/=std::cout) const {};`
so we keep a hint what that parameter means and yet satisfy the compiler. There might be more such instances but so far it looks ok.