### PR TITLE
fix clang 14 compilation

### DIFF
--- a/pmonitor/Makefile.am
+++ b/pmonitor/Makefile.am
@@ -19,7 +19,7 @@ noinst_HEADERS = $(LINKFILE)
 #ROOTCINT =  $(ROOTSYS)/bin/rootcint 
 ROOTCINT =  rootcint 
 
-AM_CPPFLAGS =  -I$(includedir)  @ROOTCFLAGS@
+AM_CPPFLAGS =  -I$(includedir) -isystem@ROOTINC@ @ROOTCFLAGS@
 
 lib_LTLIBRARIES = libpmonitor.la
 


### PR DESCRIPTION
replaced -I$(ROOTSYS) by -isystem$(ROOTSYS) so root headers don't cause warnings