### PR TITLE
add ioselect to Dict dependency to force timely creation

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -455,6 +455,7 @@ endif
 
 
 event_Dict.C : \
+  ioselect.h \
   Event.h  \
   Eventiterator.h \
   fileEventiterator.h \


### PR DESCRIPTION
scan-build with llvm 14 crashes in jenkins with a missing ioselect.h. The Makefile has one explicit dependency for it to install the header. As of a while ago we also create the dictionaries during the install header step. If this gets called before headers are installed (jenkins does seem to behave differently here, I don't se this in the daily scan build), scan-build dies with a missing ioselect.h. This PR adds ioselect.h explicitly to the dictionary dependency, so it will be created before rootcint is called