### PR TITLE
add dep on ioselect to msg dict

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -431,6 +431,7 @@ libRootmessage_la_SOURCES = \
 #  msg_dict.C
 
 msg_Dict.C : \
+  ioselect.h \
   msg_control.h \
   date_filter_msg_buffer.h \
   filter_msg_buffer.h \


### PR DESCRIPTION
This one slipped through - the msg dictionary also needs ioselect.h