### PR TITLE
comment out unused variable to make clang happy

### DIFF
--- a/newbasic/oncsSub_idmvtxv3.cc
+++ b/newbasic/oncsSub_idmvtxv3.cc
@@ -35,7 +35,7 @@ int  oncsSub_idmvtxv3::decode_lane( const std::vector<uint8_t> v)
 {
 
   uint32_t pos = 0;
-  std::vector<uint8_t>::const_iterator itr = v.begin();
+  //std::vector<uint8_t>::const_iterator itr = v.begin();
 
   int ret = 0; // currently we just print stuff, but we will add stuff to our
                // structures and return a status later (that's why it's not a const function)


### PR DESCRIPTION
oncsSub_idmvtxv3.cc did not compile with clang bc an unused local variable. This PR just comments this out 