### PR TITLE
Extend `oncsSub_idtpcfeev3` to support timeframe tagger

### DIFF
--- a/newbasic/.gitingore
+++ b/newbasic/.gitingore
@@ -1,0 +1,6 @@
+*.o
+*.lo
+configure
+config
+guess
+.deps

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -226,7 +226,7 @@ long long oncsSub_idtpcfeev3::lValue(const int n, const char *what)
     return gtm_data.size();
   }
 
-  else if (strcmp(what, "PACKET_TYPE") == 0 )
+  else if (strcmp(what, "TAGGER_TYPE") == 0 )
   {
     if (i < gtm_data.size())
     {
@@ -461,47 +461,27 @@ void  oncsSub_idtpcfeev3::dump ( OSTREAM& os )
   tpc_decode();
   identify(os);
 
-  //  std::vector<unsigned short>::const_iterator fee_data_iter[MAX_FEECOUNT];
+  if (lValue(0, "N_TAGGER") == 0)
+    os << "  No lvl1 and Endat taggers" << endl;
+  else
+  {
+    os << " TAGGER_TYPE     BCO         LEVEL1 CNT  ENDAT CNT     LAST_BCO     MODEBITS" << endl;
 
-  // for ( int i = 0 ; i < iValue(0,"MAX_FEECOUNT"); i++)
-  //   {
-  //     os << setw(4) << i << " " << fee_data[i].size()  << endl;
-  //   }
-  // os << endl;
+    for (int i = 0; i < lValue(0, "N_TAGGER"); ++i)  // go through the datasets
+    {
+      os << "  0x" << setw(4) << hex << lValue(i, "TAGGER_TYPE") << dec
+         << " (" << (lValue(i, "IS_ENDAT") ? "ENDAT" : "") << (lValue(i, "IS_LEVEL1_TRIGGER") ? "LVL1 " : "")
+         << ") "
+         << setw(12) << lValue(i, "BCO") << " "
+         << setw(10) << lValue(i, "LEVEL1_COUNT") << " "
+         << setw(10) << lValue(i, "ENDAT_COUNT") << " "
+         << setw(12) << lValue(i, "LAST_BCO")
+         << "     0x" << setw(4) << hex << lValue(i, "MODEBITS") << dec
+         << endl;
+    }
 
-  // os << "        ";
-
-  // for ( int i = 0 ; i < iValue(0,"MAX_FEECOUNT"); i++)
-  //   {
-  //     fee_data_iter[i] = fee_data[i].begin();
-  //     os << setw(8) << i;
-  //   }
-  // os << endl;
-  // os << "-----------------------------------------------" << endl;
-
-  // int still_data = 1;
-  // int count = 0;
-
-  // while (still_data)
-  //   {
-  //     os << setw(5) << count++ << " | ";
-  //     still_data = 0;
-  //     for ( int i = 0 ; i < iValue(0,"MAX_FEECOUNT"); i++)
-  // 	{
-  // 	  if (fee_data_iter[i] != fee_data[i].end())
-  // 	    {
-  // 	      os << setw(5) << hex << *(fee_data_iter[i]);
-  // 	      still_data = 1;
-  // 	      ++(fee_data_iter[i]);
-  // 	    }
-  // 	  else
-  // 	    {
-  // 	      os << setw(5) << " x ";
-  // 	    }
-  // 	}
-  //     os << dec << endl;
-  //   }
-  
+    os << endl;
+  }
   waveform_set::const_iterator wf_iter;
 
   for ( int i = 0; i < iValue(0, "NR_WF") ; i++) // go through the datasets

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -21,14 +21,19 @@ oncsSub_idtpcfeev3::oncsSub_idtpcfeev3(subevtdata_ptr data)
 oncsSub_idtpcfeev3::~oncsSub_idtpcfeev3()
 {
 
-  waveform_set::iterator itr;
-
-  for ( itr = waveforms.begin() ; itr  != waveforms.end() ; ++itr)
+  for (auto itr = waveforms.begin() ; itr  != waveforms.end() ; ++itr)
     {
       delete (*itr);
     }
   waveforms.clear();
   
+
+  for (auto itr = gtm_data.begin() ; itr  != gtm_data.end() ; ++itr)
+    {
+      delete (*itr);
+    }
+  gtm_data.clear();
+
 }
 
 int oncsSub_idtpcfeev3::cacheIterator(const int n)
@@ -228,27 +233,6 @@ int oncsSub_idtpcfeev3::iValue(const int n, const int sample)
 
 
 
-int oncsSub_idtpcfeev3::iValue(const int fee, const int ch, const int sample)
-{
-  tpc_decode();
-  return 0;
-}
-
-int oncsSub_idtpcfeev3::iValue(const int fee, const int ch, const int sample, const char *what)
-{
-  tpc_decode();
-  return 0;
-}
-
-
-int oncsSub_idtpcfeev3::iValue(const int fee, const int ch, const char *what)
-{
-
-  tpc_decode();
-
-
-  return 0;
-}
   
 
 int oncsSub_idtpcfeev3::iValue(const int n, const char *what)

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -465,7 +465,7 @@ void  oncsSub_idtpcfeev3::dump ( OSTREAM& os )
     os << "  No lvl1 and Endat taggers" << endl;
   else
   {
-    os << " TAGGER_TYPE     BCO         LEVEL1 CNT  ENDAT CNT     LAST_BCO     MODEBITS" << endl;
+    os << "  TAGGER_TYPE    BCO          LEVEL1 CNT  ENDAT CNT     LAST_BCO     MODEBITS" << endl;
 
     for (int i = 0; i < lValue(0, "N_TAGGER"); ++i)  // go through the datasets
     {
@@ -476,7 +476,7 @@ void  oncsSub_idtpcfeev3::dump ( OSTREAM& os )
          << setw(10) << lValue(i, "LEVEL1_COUNT") << " "
          << setw(10) << lValue(i, "ENDAT_COUNT") << " "
          << setw(12) << lValue(i, "LAST_BCO")
-         << "     0x" << setw(4) << hex << lValue(i, "MODEBITS") << dec
+         << "     0x" << std::setfill('0') << setw(2) << hex << lValue(i, "MODEBITS") << std::setfill(' ')<< dec
          << endl;
     }
 

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -215,6 +215,83 @@ int oncsSub_idtpcfeev3::tpc_decode ()
   return 0;
 }
 
+long long oncsSub_idtpcfeev3::lValue(const int n, const char *what)
+{
+  tpc_decode();
+
+  const size_t i = n;
+
+  if (strcmp(what, "N_TAGGER") == 0)  // the number of datasets
+  {
+    return gtm_data.size();
+  }
+
+  else if (strcmp(what, "PACKET_TYPE") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->pkt_type;
+    }
+  }
+
+  else if (strcmp(what, "IS_ENDAT") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->is_endat;
+    }
+  }
+
+  else if (strcmp(what, "IS_LEVEL1_TRIGGER") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->is_lvl1;
+    }
+  }
+
+  else if (strcmp(what, "BCO") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->bco;
+    }
+  }
+
+  else if (strcmp(what, "LEVEL1_COUNT") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->lvl1_count;
+    }
+  }
+
+  else if (strcmp(what, "ENDAT_COUNT") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->endat_count;
+    }
+  }
+
+  else if (strcmp(what, "LAST_BCO") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->last_bco;
+    }
+  }
+
+  else if (strcmp(what, "MODEBITS") == 0 )
+  {
+    if (i < gtm_data.size())
+    {
+      return gtm_data[i]->modebits;
+    }
+  }
+
+  return 0;
+}
 
 int oncsSub_idtpcfeev3::iValue(const int n, const int sample)
 {

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -59,7 +59,7 @@ int oncsSub_idtpcfeev3::decode_gtm_data(uint16_t dat[16])
     uint8_t *gtm = (uint8_t *)dat;
     gtm_payload *payload = new gtm_payload;
 
-    payload->pkt_type = gtm[0] | (gtm[1] << 8);
+    payload->pkt_type = gtm[0] | ((uint16_t)gtm[1] << 8);
     if (payload->pkt_type != GTM_LVL1_ACCEPT_MAGIC_KEY && payload->pkt_type != GTM_ENDAT_MAGIC_KEY) {
         return -1;
     }
@@ -67,10 +67,10 @@ int oncsSub_idtpcfeev3::decode_gtm_data(uint16_t dat[16])
     payload->is_lvl1 = payload->pkt_type == GTM_LVL1_ACCEPT_MAGIC_KEY;
     payload->is_endat = payload->pkt_type == GTM_ENDAT_MAGIC_KEY;
 
-    payload->bco = (gtm[2] << 0) | (gtm[3] << 8) | (gtm[4] << 16) | (gtm[5] << 24) | ((uint64_t)gtm[6] << 32) | (((uint64_t)gtm[7]) << 40);
-    payload->lvl1_count = (gtm[8] << 0) | (gtm[9] << 8) | (gtm[10] << 16) | (gtm[11] << 24);
-    payload->endat_count = (gtm[12] << 0) | (gtm[13] << 8) | (gtm[14] << 16) | (gtm[15] << 24);
-    payload->last_bco = (gtm[16] << 0) | (gtm[17] << 8) | (gtm[18] << 16) | (gtm[19] << 24) | ((uint64_t)gtm[20] << 32) | (((uint64_t)gtm[21]) << 40);
+    payload->bco = ((uint64_t)gtm[2] << 0) | ((uint64_t)gtm[3] << 8) | ((uint64_t)gtm[4] << 16) | ((uint64_t)gtm[5] << 24) | ((uint64_t)gtm[6] << 32) | (((uint64_t)gtm[7]) << 40);
+    payload->lvl1_count = ((uint32_t)gtm[8] << 0) | ((uint32_t)gtm[9] << 8) | ((uint32_t)gtm[10] << 16) | ((uint32_t)gtm[11] << 24);
+    payload->endat_count = ((uint32_t)gtm[12] << 0) | ((uint32_t)gtm[13] << 8) | ((uint32_t)gtm[14] << 16) | ((uint32_t)gtm[15] << 24);
+    payload->last_bco = ((uint64_t)gtm[16] << 0) | ((uint64_t)gtm[17] << 8) | ((uint64_t)gtm[18] << 16) | ((uint64_t)gtm[19] << 24) | ((uint64_t)gtm[20] << 32) | (((uint64_t)gtm[21]) << 40);
     payload->modebits = gtm[22];
 
     this->gtm_data.push_back(payload);

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -32,6 +32,11 @@ protected:
   static const unsigned short  MAGIC_KEY_0 = 0xfe;
   static const unsigned short  MAGIC_KEY_1 = 0x00;
 
+  static const uint16_t FEE_MAGIC_KEY = 0xfe00;
+  static const uint16_t GTM_MAGIC_KEY = 0xbb00;
+  static const uint16_t GTM_LVL1_ACCEPT_MAGIC_KEY = 0xbbf0;
+  static const uint16_t GTM_ENDAT_MAGIC_KEY = 0xbbf1;
+
   static const unsigned short  MAX_FEECOUNT = 26;   // that many FEEs
   static const unsigned short  MAX_CHANNELS   = 8*32; // that many channels per FEE
   static const unsigned short  HEADER_LENGTH  = 7;
@@ -41,7 +46,7 @@ protected:
 
   //  int find_header ( std::vector<unsigned short>::const_iterator &itr,  const std::vector<unsigned short> &orig);
   int find_header ( const unsigned int xx,  const std::vector<unsigned short> &orig);
-  
+  int decode_gtm_data(uint16_t gtm[16]);
   
   int _broken;
   
@@ -58,6 +63,17 @@ protected:
     uint16_t adc_length;
     uint16_t checksum;
     bool     valid;
+  };
+
+  struct gtm_payload {
+      uint16_t pkt_type;
+      bool is_endat;
+      bool is_lvl1;
+      uint64_t bco;
+      uint32_t lvl1_count;
+      uint32_t endat_count;
+      uint64_t last_bco;
+      uint8_t modebits;
   };
   
   // once vector per possible channel 16 cards * 256 channels
@@ -87,6 +103,7 @@ struct bco_compare {
   
   std::vector<unsigned short> fee_data[MAX_FEECOUNT];
 
+  std::vector<gtm_payload *> gtm_data;
 
 };
 

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -17,10 +17,7 @@ public:
   oncsSub_idtpcfeev3( subevtdata_ptr);
   ~oncsSub_idtpcfeev3();
 
-  int    iValue(const int fee, const int ch, const int sample);
-  int    iValue(const int fee, const int ch, const int sample, const char *what);
   int    iValue(const int ch, const int sample);
-  int    iValue(const int , const int, const char * what);
   int    iValue(const int ,const char * what);
 
   void  dump ( OSTREAM& os = COUT) ;
@@ -32,7 +29,7 @@ protected:
   static const unsigned short  MAGIC_KEY_0 = 0xfe;
   static const unsigned short  MAGIC_KEY_1 = 0x00;
 
-  static const uint16_t FEE_MAGIC_KEY = 0xfe00;
+  static const uint16_t FEE_MAGIC_KEY = 0xba00;
   static const uint16_t GTM_MAGIC_KEY = 0xbb00;
   static const uint16_t GTM_LVL1_ACCEPT_MAGIC_KEY = 0xbbf0;
   static const uint16_t GTM_ENDAT_MAGIC_KEY = 0xbbf1;

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -17,8 +17,12 @@ public:
   oncsSub_idtpcfeev3( subevtdata_ptr);
   ~oncsSub_idtpcfeev3();
 
+  //! SAMPA waveform interfaces
   int    iValue(const int ch, const int sample);
   int    iValue(const int ,const char * what);
+
+  //! Expose the Level 1 trigger and endat taggers
+  long long  lValue(const int channel, const char *what) ;
 
   void  dump ( OSTREAM& os = COUT) ;
 


### PR DESCRIPTION
Extend `oncsSub_idtpcfeev3` to support timeframe tagger, which mark begin (level-1 trigger) and end (Endat) of a TPC timeframe which allows for: 
1. TPC timeframe building with respect to each level-1 trigger, even without GL1 PRDF
2. QA check TPC triggers against GL1 events
3. QA check TPC waveforms against trigger throttling window that is marked by the  begin and end taggers
4. Mark overlapping timeframes below to two or more close-by triggers

Tested with recent runs: 
```
ddump -n 30  /sphenix/lustre01/sphnxpro/rawdata/commissioning/tpc/pedestal/TPC_ebdc14_pedestal-00010628-0000.prdf  | grep Packet -A 5
Packet  4140 16388 -1 (sPHENIX Packet) 120 (IDTPCFEEV3)
  TAGGER_TYPE    BCO          LEVEL1 CNT  ENDAT CNT     LAST_BCO     MODEBITS
  0xbbf0 (LVL1 ) 470515440507       7092       7047 465474563130     0x00
  0xbbf1 (ENDAT) 470515440525       7093       7047 470515440507     0x00

  FEE   Channel   Sampachannel   Samples     BCO     CRC_ERR
--
Packet  4141 16388 -1 (sPHENIX Packet) 120 (IDTPCFEEV3)
  TAGGER_TYPE    BCO          LEVEL1 CNT  ENDAT CNT     LAST_BCO     MODEBITS
  0xbbf0 (LVL1 ) 470515440507       7092       7047 465474563130     0x00
  0xbbf1 (ENDAT) 470515440525       7093       7047 470515440507     0x00

```
And used in downstream analysis module: https://github.com/blackcathj/analysis/commit/be86ce858d57f65abe90a88e90a754b17408d74d