### PR TITLE
mlp - fixed a segfault if the packet happens to have no data

### DIFF
--- a/newbasic/packet_idcstr.cc
+++ b/newbasic/packet_idcstr.cc
@@ -36,9 +36,11 @@ int *Packet_idcstr::decode ( int *nwout)
 
   int dlength = getDataLength();
 
-  //   std::cout << __FILE__ << "  " << __LINE__ << " datalength: " 
-  //	      << getDataLength() << " padding " << getPadding() << std::endl;
+  // std::cout << __FILE__ << "  " << __LINE__ << " datalength: " 
+  // 	    << getDataLength() << " padding " << getPadding() << std::endl;
 
+  if ( dlength <=0) dlength =1; // need at least an array of 1
+   
   unsigned char *SubeventData = ( unsigned char * ) findPacketDataStart(packet);
   sarray = new unsigned char[dlength+1];
   memcpy ( sarray, SubeventData,dlength); 


### PR DESCRIPTION
We came across never-seen-before 0-length idcstr packets that caused a segfault. Fixed.