### PR TITLE
added support for the "packed" / zero-suppressed calorimeter hitformats

### DIFF
--- a/newbasic/A_Event.cc
+++ b/newbasic/A_Event.cc
@@ -652,6 +652,23 @@ Packet *A_Event::makePacket(PHDWORD *pp, const int hitFormat)
       return new Packet_iddigitizerv2(pp);
       break;
 
+    case  IDDIGITIZERV3_2S:
+    case  IDDIGITIZERV3_4S:
+    case  IDDIGITIZERV3_6S:
+    case  IDDIGITIZERV3_8S:
+    case  IDDIGITIZERV3_12S:
+    case  IDDIGITIZERV3_14S:
+    case  IDDIGITIZERV3_18S:
+    case  IDDIGITIZERV3_20S:
+    case  IDDIGITIZERV3_22S:
+    case  IDDIGITIZERV3_24S:
+    case  IDDIGITIZERV3_26S:
+    case  IDDIGITIZERV3_28S:
+    case  IDDIGITIZERV3_30S:
+
+      return new Packet_iddigitizerv3(pp);
+      break;
+
     case IDLL1_20S:
     case IDLL1v2_20S:
       return new Packet_idll1v1(pp);

--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -185,6 +185,7 @@ allheaders = \
   packet_id4evt.h \
   packet_id4scaler.h \
   packet_iddigitizerv2.h \
+  packet_iddigitizerv3.h \
   packet_idll1v1.h \
   packet_w124.h \
   packet_cdevpolarimeter.h \
@@ -282,6 +283,7 @@ allsources = \
   packet_id4evt.cc \
   packet_id4scaler.cc \
   packet_iddigitizerv2.cc \
+  packet_iddigitizerv3.cc \
   packet_idll1v1.cc \
   packet_mnemonic.cc \
   packet_w124.cc \

--- a/newbasic/configure.ac
+++ b/newbasic/configure.ac
@@ -9,6 +9,8 @@ AM_CONDITIONAL(NEWIO, false)
 AC_CANONICAL_HOST
 AC_CONFIG_AUX_DIR([.])
 
+#CXXFLAGS="-O0 -g"
+
 dnl search for C++ compiler and set default flags
 AC_PROG_CXX(cxx CC g++)
 

--- a/newbasic/oncsSub_idinttv0.cc
+++ b/newbasic/oncsSub_idinttv0.cc
@@ -121,6 +121,16 @@ int oncsSub_idinttv0::intt_decode ()
 	}
     }
 
+  // for ( int fee = 0; fee < MAX_FEECOUNT; fee++)
+  //   {
+  //     for ( unsigned int i = 0; i < fee_data[fee].size(); i++)
+  // 	{
+  // 	  cout << setw(3) << fee << "  " << hex << fee_data[fee][i] << dec << endl;
+  // 	}
+  //     cout << endl;
+  //   }
+  
+
 
   for ( int fee = 0 ; fee < MAX_FEECOUNT ; fee++)
     {
@@ -153,7 +163,14 @@ int oncsSub_idinttv0::intt_decode ()
 	  // here j points to a "cade" word
 
 	  // push back the cdae word, the BCO, and event counter
-	  for ( int k = 0; k < 3; k++) hitlist.push_back(fee_data[fee][j++]);
+	  if ( fee_data[fee].size() >=3 )
+	    {
+	      for ( int k = 0; k < 3; k++) hitlist.push_back(fee_data[fee][j++]);
+	    }
+	  else
+	    {
+	      coutfl << " Warning - size is " << fee_data[fee].size() << endl;
+	    }
 	  
 
 	  // ok, now let's go until we hit the end, or hit the next header, or a footer

--- a/newbasic/oncsSub_idinttv0.cc
+++ b/newbasic/oncsSub_idinttv0.cc
@@ -109,8 +109,8 @@ int oncsSub_idinttv0::intt_decode ()
 	}
 
       
-      uint16_t fee = ( buffer[index] >> 20 ) & 0xf;
-      uint16_t len = ( (buffer[index] >> 16) & 0xf) >>1;
+      unsigned short fee = ( buffer[index] >> 20 ) & 0xf;
+      unsigned short len = ( (buffer[index] >> 16) & 0xf) >>1;
       //coutfl << "found start at index " << index << " values " << hex << buffer[index] << dec << " fee: " << fee << " len: " << len << endl;
       index++;
 
@@ -166,7 +166,7 @@ int oncsSub_idinttv0::intt_decode ()
 		  header_found  = 0;
 		  j--;
 		  // we have a full hitlist in the vector here
-		  coutfl << "calling decode with size " << hitlist.size() << endl;
+		  //coutfl << "calling decode with size " << hitlist.size() << endl;
 		  intt_decode_hitlist (hitlist, fee);
 		  hitlist.clear();
 		  break;

--- a/newbasic/oncsSub_idinttv0.h
+++ b/newbasic/oncsSub_idinttv0.h
@@ -48,17 +48,17 @@ protected:
   struct intt_hit
   {
     uint64_t bco;
-    uint16_t fee;
-    uint16_t channel_id;
-    uint16_t chip_id;
-    uint16_t adc;
-    uint16_t FPHX_BCO;
-    uint16_t full_FPHX;
-    uint16_t full_ROC;
-    uint16_t amplitude;
-    uint16_t full_fphx;
-    uint32_t event_counter;
-    uint32_t word;
+    unsigned short fee;
+    unsigned short channel_id;
+    unsigned short chip_id;
+    unsigned short adc;
+    unsigned short FPHX_BCO;
+    unsigned short full_FPHX;
+    unsigned short full_ROC;
+    unsigned short amplitude;
+    unsigned short full_fphx;
+    unsigned int event_counter;
+    unsigned int word;
   };
 
     

--- a/newbasic/oncsSub_idinttv0.h
+++ b/newbasic/oncsSub_idinttv0.h
@@ -47,7 +47,7 @@ protected:
 
   struct intt_hit
   {
-    uint64_t bco;
+    unsigned long long bco;
     unsigned short fee;
     unsigned short channel_id;
     unsigned short chip_id;

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -68,10 +68,10 @@ int oncsSub_idtpcfeev3::decode_gtm_data(unsigned short dat[16])
     payload->is_lvl1 = payload->pkt_type == GTM_LVL1_ACCEPT_MAGIC_KEY;
     payload->is_endat = payload->pkt_type == GTM_ENDAT_MAGIC_KEY;
 
-    payload->bco = ((uint64_t)gtm[2] << 0) | ((uint64_t)gtm[3] << 8) | ((uint64_t)gtm[4] << 16) | ((uint64_t)gtm[5] << 24) | ((uint64_t)gtm[6] << 32) | (((uint64_t)gtm[7]) << 40);
+    payload->bco = ((unsigned long long)gtm[2] << 0) | ((unsigned long long)gtm[3] << 8) | ((unsigned long long)gtm[4] << 16) | ((unsigned long long)gtm[5] << 24) | ((unsigned long long)gtm[6] << 32) | (((unsigned long long)gtm[7]) << 40);
     payload->lvl1_count = ((unsigned int)gtm[8] << 0) | ((unsigned int)gtm[9] << 8) | ((unsigned int)gtm[10] << 16) | ((unsigned int)gtm[11] << 24);
     payload->endat_count = ((unsigned int)gtm[12] << 0) | ((unsigned int)gtm[13] << 8) | ((unsigned int)gtm[14] << 16) | ((unsigned int)gtm[15] << 24);
-    payload->last_bco = ((uint64_t)gtm[16] << 0) | ((uint64_t)gtm[17] << 8) | ((uint64_t)gtm[18] << 16) | ((uint64_t)gtm[19] << 24) | ((uint64_t)gtm[20] << 32) | (((uint64_t)gtm[21]) << 40);
+    payload->last_bco = ((unsigned long long)gtm[16] << 0) | ((unsigned long long)gtm[17] << 8) | ((unsigned long long)gtm[18] << 16) | ((unsigned long long)gtm[19] << 24) | ((unsigned long long)gtm[20] << 32) | (((unsigned long long)gtm[21]) << 40);
     payload->modebits = gtm[22];
 
     this->gtm_data.push_back(payload);

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -54,12 +54,12 @@ int oncsSub_idtpcfeev3::cacheIterator(const int n)
   return 1;
 }
 
-int oncsSub_idtpcfeev3::decode_gtm_data(uint16_t dat[16])
+int oncsSub_idtpcfeev3::decode_gtm_data(unsigned short dat[16])
 {
-    uint8_t *gtm = (uint8_t *)dat;
+    unsigned char *gtm = (unsigned char *)dat;
     gtm_payload *payload = new gtm_payload;
 
-    payload->pkt_type = gtm[0] | ((uint16_t)gtm[1] << 8);
+    payload->pkt_type = gtm[0] | ((unsigned short)gtm[1] << 8);
     if (payload->pkt_type != GTM_LVL1_ACCEPT_MAGIC_KEY && payload->pkt_type != GTM_ENDAT_MAGIC_KEY) {
       delete payload;
       return -1;
@@ -69,8 +69,8 @@ int oncsSub_idtpcfeev3::decode_gtm_data(uint16_t dat[16])
     payload->is_endat = payload->pkt_type == GTM_ENDAT_MAGIC_KEY;
 
     payload->bco = ((uint64_t)gtm[2] << 0) | ((uint64_t)gtm[3] << 8) | ((uint64_t)gtm[4] << 16) | ((uint64_t)gtm[5] << 24) | ((uint64_t)gtm[6] << 32) | (((uint64_t)gtm[7]) << 40);
-    payload->lvl1_count = ((uint32_t)gtm[8] << 0) | ((uint32_t)gtm[9] << 8) | ((uint32_t)gtm[10] << 16) | ((uint32_t)gtm[11] << 24);
-    payload->endat_count = ((uint32_t)gtm[12] << 0) | ((uint32_t)gtm[13] << 8) | ((uint32_t)gtm[14] << 16) | ((uint32_t)gtm[15] << 24);
+    payload->lvl1_count = ((unsigned int)gtm[8] << 0) | ((unsigned int)gtm[9] << 8) | ((unsigned int)gtm[10] << 16) | ((unsigned int)gtm[11] << 24);
+    payload->endat_count = ((unsigned int)gtm[12] << 0) | ((unsigned int)gtm[13] << 8) | ((unsigned int)gtm[14] << 16) | ((unsigned int)gtm[15] << 24);
     payload->last_bco = ((uint64_t)gtm[16] << 0) | ((uint64_t)gtm[17] << 8) | ((uint64_t)gtm[18] << 16) | ((uint64_t)gtm[19] << 24) | ((uint64_t)gtm[20] << 32) | (((uint64_t)gtm[21]) << 40);
     payload->modebits = gtm[22];
 
@@ -115,7 +115,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
         }
       }
     } else if ((buffer[index] & 0xFF00) == GTM_MAGIC_KEY) {
-        uint16_t buf[16];
+        unsigned short buf[16];
 
         // memcpy?
         for (unsigned int i = 0; i < 16; i++) {
@@ -166,7 +166,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 	  else
 	    {
 	      // capture the header so we can easier get the bit shift stuff
-	      uint16_t header[HEADER_LENGTH];
+	      unsigned short header[HEADER_LENGTH];
 	      for ( int i = 0; i < HEADER_LENGTH; i++ ) header[i] = (fee_data[ifee][pos++]) ;
 
 	      sampa_waveform *sw = new sampa_waveform;
@@ -182,7 +182,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 		| (header[1] >> 9);	  
 
 	      // now we add the actual waveform
-	      uint16_t data_size = header[5] -1 ;
+	      unsigned short data_size = header[5] -1 ;
 
 	     //  coutfl << " Fee: " << ifee << " Sampa " << sw->sampa_address
 	     //  	 << " sampa channel: " << sw->sampa_channel
@@ -195,7 +195,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 		}
 	      
 	      // we calculate the checksum here because "pos" is at the right place
-	      uint16_t crc = crc16(ifee, startpos, header[0]-1);
+	      unsigned short crc = crc16(ifee, startpos, header[0]-1);
 	      // coutfl << "fee " << setw(3) << sw->fee
 	      // 	     << " sampla channel " << setw(3) <<  sw->channel
 	      // 	     << " crc and value " << hex << setw(5) << crc << " " << setw(5) << fee_data[ifee][pos] << dec;

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -33,10 +33,10 @@ protected:
   static const unsigned short  MAGIC_KEY_0 = 0xfe;
   static const unsigned short  MAGIC_KEY_1 = 0x00;
 
-  static const uint16_t FEE_MAGIC_KEY = 0xba00;
-  static const uint16_t GTM_MAGIC_KEY = 0xbb00;
-  static const uint16_t GTM_LVL1_ACCEPT_MAGIC_KEY = 0xbbf0;
-  static const uint16_t GTM_ENDAT_MAGIC_KEY = 0xbbf1;
+  static const unsigned short FEE_MAGIC_KEY = 0xba00;
+  static const unsigned short GTM_MAGIC_KEY = 0xbb00;
+  static const unsigned short GTM_LVL1_ACCEPT_MAGIC_KEY = 0xbbf0;
+  static const unsigned short GTM_ENDAT_MAGIC_KEY = 0xbbf1;
 
   static const unsigned short  MAX_FEECOUNT = 26;   // that many FEEs
   static const unsigned short  MAX_CHANNELS   = 8*32; // that many channels per FEE
@@ -47,34 +47,34 @@ protected:
 
   //  int find_header ( std::vector<unsigned short>::const_iterator &itr,  const std::vector<unsigned short> &orig);
   int find_header ( const unsigned int xx,  const std::vector<unsigned short> &orig);
-  int decode_gtm_data(uint16_t gtm[16]);
+  int decode_gtm_data(unsigned short gtm[16]);
   
   int _broken;
   
   int _is_decoded;
 
   struct sampa_waveform {
-    uint16_t fee;
-    uint16_t pkt_length;
-    uint16_t channel;
-    uint16_t sampa_channel;
-    uint16_t sampa_address;
-    uint32_t bx_timestamp;
-    std::vector<uint16_t> waveform;
-    uint16_t adc_length;
-    uint16_t checksum;
+    unsigned short fee;
+    unsigned short pkt_length;
+    unsigned short channel;
+    unsigned short sampa_channel;
+    unsigned short sampa_address;
+    unsigned int bx_timestamp;
+    std::vector<unsigned short> waveform;
+    unsigned short adc_length;
+    unsigned short checksum;
     bool     valid;
   };
 
   struct gtm_payload {
-      uint16_t pkt_type;
+      unsigned short pkt_type;
       bool is_endat;
       bool is_lvl1;
       uint64_t bco;
-      uint32_t lvl1_count;
-      uint32_t endat_count;
+      unsigned int lvl1_count;
+      unsigned int endat_count;
       uint64_t last_bco;
-      uint8_t modebits;
+      unsigned char modebits;
   };
   
   // once vector per possible channel 16 cards * 256 channels

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -70,10 +70,10 @@ protected:
       unsigned short pkt_type;
       bool is_endat;
       bool is_lvl1;
-      uint64_t bco;
+      unsigned long long bco;
       unsigned int lvl1_count;
       unsigned int endat_count;
-      uint64_t last_bco;
+      unsigned long long last_bco;
       unsigned char modebits;
   };
   

--- a/newbasic/packetConstants.h
+++ b/newbasic/packetConstants.h
@@ -303,13 +303,32 @@
 #define IDDIGITIZER_12S     94
 #define IDDIGITIZER_16S     95
 
-#define IDLL1_20S           141
+#define IDDIGITIZERV3_2S      162
+#define IDDIGITIZERV3_4S      164
+#define IDDIGITIZERV3_6S      166
+#define IDDIGITIZERV3_8S      168
+#define IDDIGITIZERV3_10S     170
+#define IDDIGITIZERV3_12S     172
+#define IDDIGITIZERV3_14S     174
+#define IDDIGITIZERV3_16S     176
+#define IDDIGITIZERV3_18S     178
+#define IDDIGITIZERV3_20S     180
+#define IDDIGITIZERV3_22S     182
+#define IDDIGITIZERV3_24S     184
+#define IDDIGITIZERV3_26S     186
+#define IDDIGITIZERV3_28S     188
+#define IDDIGITIZERV3_30S     190
+
+#define IDLL1_20S             141
 #define IDLL1v2_20S           142
+
 
 #define IDDIGITIZER_CTRL     2099
 
+// LL1 
 
-
+#define IDLL1_20S 141
+#define IDLL1v2_20S 142
 
 // EMC data header and trailer length
 

--- a/newbasic/packet_collection.h
+++ b/newbasic/packet_collection.h
@@ -12,6 +12,7 @@
 
 #include "packet_id4scaler.h"
 #include "packet_iddigitizerv2.h"
+#include "packet_iddigitizerv3.h"
 #include "packet_idll1v1.h"
 
 #include "packet_cdevpolarimeter.h"

--- a/newbasic/packet_iddigitizerv3.cc
+++ b/newbasic/packet_iddigitizerv3.cc
@@ -1,0 +1,431 @@
+#include "packet_iddigitizerv3.h"
+
+#include <string.h>
+
+using namespace std;
+
+
+#define coutfl std::cout << __FILE__<< "  " << __LINE__ << " "
+#define cerrfl std::cerr << __FILE__<< "  " << __LINE__ << " "
+
+
+Packet_iddigitizerv3::Packet_iddigitizerv3(PACKET_ptr data)
+  :Packet_w4 (data)
+{
+
+  _broken = 0;
+  
+  if ( getHitFormat() > 160 && getHitFormat() <= 190)
+    {
+      _nsamples = getHitFormat() - 160;
+    }
+  _nchannels = 0;
+  _nr_modules = 0;
+  
+  _evtnr = 0;
+  _flagword = 0;
+  _detid = 0;
+  _module_address  = 0;
+  _xmit_clock = 0;
+  
+  for ( int i = 0; i < NR_FEMS; i++)
+    {
+      _fem_slot[i] = 0;
+      _fem_evtnr[i] = 0;
+      _fem_clock[i] = 0;
+      _fem_checksum_MSB[i] = 0;
+      _fem_checksum_LSB[i] = 0;
+      _fem_calculated_checksum_MSB[i] = 0;
+      _fem_calculated_checksum_LSB[i] = 0;
+
+    }
+  
+  _is_decoded = 0;
+  
+}
+
+
+Packet_iddigitizerv3::~Packet_iddigitizerv3()
+{
+
+}
+
+int Packet_iddigitizerv3::decode ()
+{
+
+  if (_is_decoded ) return 0;
+  _is_decoded = 1;
+  
+  unsigned int *k;
+
+
+  // check later  int dlength = ( getLength()-4) - getPadding();
+
+  unsigned int *SubeventData = (unsigned int *) findPacketDataStart(packet); 
+
+  int dlength = getDataLength();
+  
+  k = SubeventData;  // we make a shorter variale for less typing..
+
+  
+  for (int i = 0; i < 32; i++)
+    {
+      for (int j = 0; j < 4*64; j++)
+	{
+	  adc[i][j] = 0;
+	}
+    }
+
+  if ( dlength < 6 )
+    {
+      _broken = 1;
+      return 0;  //safety belt
+    }
+  
+  // we have here - 
+  //  [0]  0x8000xxxx  with xxxx = evt nr
+  //  [1]  0x9000xxxx  with xxxx = flag word
+  //  [2]  0x9000xxxx  with xxxx = det id
+  //  [3]  0x9000xxxx  with xxxx = module address
+  //  [4]  0x9000xxxx  with xxxx = xmit clock nr
+  
+  if ( (k[0] >> 28) != 0x8)  return 1;
+  if ( (k[1] >> 28) != 0x9)  return 1;
+  if ( (k[2] >> 28) != 0x9)  return 1;
+  if ( (k[3] >> 28) != 0x9)  return 1;
+  if ( (k[4] >> 28) != 0x9)  return 1;
+
+  _evtnr          = (k[0] & 0xffff);	    
+  _flagword       = (k[1] & 0xffff);	    
+  _detid          = (k[2] & 0xffff);	    
+  _module_address = (k[3] & 0xffff);	    
+  _xmit_clock     = (k[4] & 0xffff);	    
+ 
+  
+  int fem_nr = 0;
+  
+  for (int fem_index = 5; fem_index < dlength ; )  // we hop from FEM to FEM here
+    {
+
+      if ( k[fem_index] == 0xa000ffff)
+	{
+	  //coutfl << " FEM_ start at  " << fem_index << "   " << hex << k[fem_index] << dec  << endl;
+	  
+	  unsigned int i = decode_FEM (  &k[fem_index], fem_nr, dlength - fem_index); // we make "i" so we can debug
+	  if ( i == 0)
+	    {
+	      //coutfl << " strange return " << i << endl;
+	      _broken = 2;
+	      break;  // no endless loops...
+	    }
+	  fem_nr++;
+	  if ( fem_nr >= NR_FEMS)
+	    {
+	      _broken = 3;
+	      return 1;
+	    }
+	  fem_index += i;
+	  //coutfl << " fem_index now  " << fem_index << "  " << hex <<  k[fem_index] << dec << endl;
+	}
+    }
+
+  return 0;
+}
+
+
+unsigned int Packet_iddigitizerv3::decode_FEM ( unsigned int *k, const int fem_nr, const int len)
+{
+  int NFEM = 0;
+  int CHNL = 0;
+  int index_channel = 0;
+  int index_sample = 0;
+  int index_parity = 0;
+
+  //coutfl << " calling decode_FEM for fem " << fem_nr << endl;
+
+  
+  // should have been checked but let's be sure
+  if ( k[0] != 0xa000ffff) return 0;
+  
+  _fem_slot[fem_nr]  = k[1] & 0xffff;
+  _fem_evtnr[fem_nr] = k[2] & 0xffff;
+  _fem_clock[fem_nr] = k[3] & 0xffff;
+
+  _nr_modules++;
+  _nchannels += 64;  
+
+  int index;
+
+  // for ( index = 1; index < 4; index++)
+  //   {
+  //     _fem_calculated_checksum_MSB[NFEM] ^= ((k[index] >> 16 ) & 0xffff);
+  //     _fem_calculated_checksum_LSB[NFEM] ^= (k[index] & 0xffff);
+  //   }
+
+
+  for ( index = 4; index < len; index++)
+    {
+      int word_classifier = k[index] >> 28;
+      
+      if ( word_classifier == 0x1) // FEM/Ch address
+	{
+	  // _fem_calculated_checksum_MSB[NFEM] ^= ((k[index] >> 16 ) & 0xffff);
+	  // _fem_calculated_checksum_LSB[NFEM] ^= (k[index] & 0xffff);
+
+	  NFEM = (k[index] >> 6) & 0x7;
+	  CHNL   = k[index] & 0x3f;
+	  //coutfl << "new NFEM and channel - " << NFEM << " " << CHNL << "   "  << hex << k[index] << dec << endl;
+	  if (NFEM != fem_nr || NFEM >= NR_FEMS)
+	    {
+	      coutfl << "NFEM and fem_nr differ - " << NFEM << " " << fem_nr << "  " << hex << k[index] << dec << endl;
+	    }
+	  // we have a new channel. reset the sample and parity index, and set the channel index
+	  index_sample = 0;
+	  index_parity = 0;  
+	  index_channel = NFEM*64+CHNL;
+	  // we assume we are zero-suppressed and reset this if we find later that we are not
+	  isZeroSuppressed[index_channel] = true;
+	}
+
+      else if ( word_classifier == 0x3)  // two samples
+	{
+	  _fem_calculated_checksum_MSB[NFEM] ^= k[index] & 0x3fff;
+	  _fem_calculated_checksum_LSB[NFEM] ^= (k[index] >> 14) & 0x3fff;
+
+
+	  adc[index_sample++][index_channel] = k[index] & 0x3fff;
+	  adc[index_sample++][index_channel] = (k[index] >> 14) & 0x3fff;
+	  isZeroSuppressed[index_channel] = false; // we are ot zero-sppressed
+	}
+
+      else if ( word_classifier == 0xe)   // suppressed channel info
+	{
+	  // _fem_calculated_checksum_MSB[NFEM] ^= ((k[index] >> 16 ) & 0xffff);
+	  // _fem_calculated_checksum_LSB[NFEM] ^= (k[index] & 0xffff);
+
+	  pre_post[0][index_channel] = (k[index] & 0x3fff);
+	  pre_post[1][index_channel] = ((k[index]>>14) & 0x3fff);
+	}
+
+      else if ( word_classifier == 0xb)   // parity info
+	{
+	  if ( index_parity == 0)
+	    {
+	      _fem_checksum_MSB[NFEM] = (k[index] & 0xffff);
+	      index_parity++;
+	    }
+	  else
+	    {
+	      _fem_checksum_LSB[NFEM] = (k[index] & 0xffff);
+	      break;
+	    }
+
+	}
+    }
+  return index+1;
+}
+
+
+int Packet_iddigitizerv3::iValue(const int sample, const int ch)
+{
+  decode();
+
+  
+  if ( sample >= _nsamples || sample < 0 
+       || ch >= _nchannels || ch < 0 ) return 0;
+ 
+  return adc[sample][ch];
+  return 0;
+}
+
+int Packet_iddigitizerv3::iValue(const int n, const char *what)
+{
+
+  decode();
+
+  if ( strcmp(what,"CLOCK") == 0 )
+  {
+    return _xmit_clock;
+  }
+
+  if ( strcmp(what,"EVTNR") == 0 )
+  {
+    return _evtnr;
+  }
+
+  if ( strcmp(what,"SAMPLES") == 0 )
+  {
+    return _nsamples;
+  }
+
+  if ( strcmp(what,"NRMODULES") == 0 )
+  {
+    return _nr_modules;
+  }
+
+
+  if ( strcmp(what,"CHANNELS") == 0 )
+  {
+    return _nchannels;
+  }
+
+  if ( strcmp(what,"DETID") == 0 )
+  {
+    return _detid;
+  }
+
+  if ( strcmp(what,"MODULEADDRESS") == 0 )
+  {
+    return _module_address;
+  }
+
+
+  if ( strcmp(what,"FEMSLOT") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_slot[n];
+  }
+
+  if ( strcmp(what,"FEMEVTNR") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_evtnr[n];
+  }
+
+  if ( strcmp(what,"FEMCLOCK") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_clock[n];
+  }
+
+  if ( strcmp(what,"CHECKSUMMSB") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_checksum_MSB[n];
+  }
+
+  if ( strcmp(what,"CHECKSUMLSB") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_checksum_LSB[n];
+  }
+
+  if ( strcmp(what,"CALCCHECKSUMMSB") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_calculated_checksum_MSB[n];
+  }
+
+  if ( strcmp(what,"CALCCHECKSUMLSB") == 0 )
+  {
+    if ( n < 0 || n >= _nr_modules) return 0;
+    return _fem_calculated_checksum_LSB[n];
+  }
+
+  if ( strcmp(what,"PRE") == 0 )
+  {
+    if ( n < 0 || n >= _nchannels ) return 0;
+    return pre_post[0][n];
+  }
+
+  if ( strcmp(what,"POST") == 0 )
+  {
+    if ( n < 0 || n >= _nchannels ) return 0;
+    return pre_post[1][n];
+  }
+
+  if ( strcmp(what,"SUPPRESSED") == 0 )
+  {
+    if ( n < 0 || n >= _nchannels ) return 0;
+    if ( isZeroSuppressed[n] ) return 1;
+    return 0;
+  }
+
+
+  return 0;
+
+}
+
+void  Packet_iddigitizerv3::dump ( OSTREAM& os )
+{
+  identify(os);
+
+  if ( _broken)
+    {
+      os << " *** Corrupt packet "  << std::endl;
+      return;
+    }
+  
+  os << "Evt Nr:      " << iValue(0,"EVTNR") << std::endl;
+  os << "Clock:       " << iValue(0,"CLOCK") << std::endl;
+  os << "Nr Modules:  " << iValue(0,"NRMODULES") << std::endl;
+  os << "Channels:    " << iValue(0,"CHANNELS") << std::endl;
+  os << "Samples:     " << iValue(0,"SAMPLES") << std::endl;
+  os << "Det. ID:     " << hex << "0x" << iValue(0,"DETID") << dec <<  std::endl;
+  os << "Mod. Addr:   " << hex << "0x" << iValue(0,"MODULEADDRESS") << dec << std::endl;
+
+  os << "FEM Slot:    ";
+  for ( int i = 0; i < iValue(0,"NRMODULES"); i++) os << setw(8) << iValue(i,"FEMSLOT");
+  os <<  std::endl;
+
+  os << "FEM Evt nr:  ";
+  for ( int i = 0; i < iValue(0,"NRMODULES"); i++)  os << setw(8) << iValue(i,"FEMEVTNR");
+  os << std::endl;
+
+  os << "FEM Clock:   ";
+  for ( int i = 0; i < iValue(0,"NRMODULES"); i++)  os << setw(8) << iValue(i,"FEMCLOCK");
+  os << std::endl;
+
+  char oldFill=os.fill('0');
+  
+  os << "FEM Checksum LSB:   ";
+  for ( int i = 0; i < iValue(0,"NRMODULES"); i++)
+    {
+      os <<  "0x" << hex <<  setw(4) << iValue(i,"CHECKSUMLSB") << "  "  << dec;
+    }
+  os << std::endl;
+
+  // os << "Calculated Checksum LSB:   ";
+  // for ( int i = 0; i < iValue(0,"NRMODULES"); i++)
+  //   {
+  //     os <<  "0x" << hex <<  setw(4) << iValue(i,"CALCCHECKSUMLSB") << "  "  << dec;
+  //   }
+  // os << std::endl;
+
+  os << "FEM Checksum MSB:   ";
+  for ( int i = 0; i < iValue(0,"NRMODULES"); i++)
+    {
+      os <<  "0x" << hex << setw(4) << iValue(i,"CHECKSUMMSB")  << "  "<< dec;
+    }
+  os << std::endl;
+
+  // os << "Calculated Checksum MSB:   ";
+  // for ( int i = 0; i < iValue(0,"NRMODULES"); i++)
+  //   {
+  //     os <<  "0x" << hex <<  setw(4) << iValue(i,"CALCCHECKSUMMSB") << "  "  << dec;
+  //   }
+  // os << std::endl;
+
+  os.fill(oldFill);
+  os << endl;
+
+  for ( int c = 0; c < _nchannels; c++)
+    {
+      os << setw(4) << c << " | ";
+
+      os << hex;
+
+      os << setw(6) << iValue(c, "PRE");
+      os << setw(6) << iValue(c, "POST") << " | " ;
+
+      if ( ! iValue(c,"SUPPRESSED") )
+	{
+	  for ( int s = 0; s < _nsamples; s++)
+	    {
+	      os << setw(6) << iValue(s,c);
+	    }
+	}
+      os << dec << endl;
+    }
+
+}

--- a/newbasic/packet_iddigitizerv3.h
+++ b/newbasic/packet_iddigitizerv3.h
@@ -1,0 +1,61 @@
+#ifndef __PACKET_IDDIGITIZERV3_H__
+#define __PACKET_IDDIGITIZERV3_H__
+
+
+#include "packet_w124.h"
+
+#ifndef __CINT__
+class WINDOWSEXPORT Packet_iddigitizerv3 : public  Packet_w4 {
+#else
+class  Packet_iddigitizerv3 : public  Packet_w4 {
+#endif
+
+public:
+  Packet_iddigitizerv3( PACKET_ptr);
+  ~Packet_iddigitizerv3();
+
+  int    iValue(const int sample, const int ch);
+  int    iValue(const int ,const char * what);
+  void  dump ( OSTREAM& os = COUT) ;
+
+
+protected:
+  int decode ();
+  unsigned int decode_FEM ( unsigned int *k, const int fem_nr, const int len);
+
+  int _broken;
+
+#define NR_FEMS 4
+
+  // header info per packet
+  int _evtnr;
+  int _flagword;
+  int _detid;
+  int _module_address;
+  int _xmit_clock;
+
+  // info per FEM
+  int _fem_slot[NR_FEMS];
+  int _fem_evtnr[NR_FEMS];
+  int _fem_clock[NR_FEMS];
+
+    int _fem_checksum_MSB[NR_FEMS];
+  int _fem_checksum_LSB[NR_FEMS];
+  int _fem_calculated_checksum_MSB[NR_FEMS];
+  int _fem_calculated_checksum_LSB[NR_FEMS];
+
+  int _nsamples;
+  int _nr_modules;
+
+  int _nchannels;
+  int _is_decoded;
+
+  int adc[32][NR_FEMS*64];
+  int pre_post[2][NR_FEMS*64];
+
+  bool isZeroSuppressed[NR_FEMS*64];
+
+};
+
+
+#endif /* __PACKET_IDDIGITIZERV3_H__ */

--- a/newbasic/packet_mnemonic.cc
+++ b/newbasic/packet_mnemonic.cc
@@ -20,9 +20,30 @@ const char *get_mnemonic (const int structure, const int format)
     case(ID4EVT): return "ID4EVT";
     case(ID2SUP): return "ID2SUP";
     case(ID4SCALER): return "ID4SCALER";
+
     case(IDDIGITIZER_12S): return "IDDIGITIZER_12S";
     case(IDDIGITIZER_16S): return "IDDIGITIZER_16S";
     case(IDDIGITIZER_31S): return "IDDIGITIZER_31S";
+      
+    case(IDDIGITIZERV3_2S): return "IDDIGITIZERV3_2S";
+    case(IDDIGITIZERV3_4S): return "IDDIGITIZERV3_4S";
+    case(IDDIGITIZERV3_6S): return "IDDIGITIZERV3_6S";
+    case(IDDIGITIZERV3_8S): return "IDDIGITIZERV3_8S";
+
+    case(IDDIGITIZERV3_10S): return "IDDIGITIZERV3_10S";
+    case(IDDIGITIZERV3_12S): return "IDDIGITIZERV3_12S";
+    case(IDDIGITIZERV3_14S): return "IDDIGITIZERV3_14S";
+    case(IDDIGITIZERV3_16S): return "IDDIGITIZERV3_16S";
+    case(IDDIGITIZERV3_18S): return "IDDIGITIZERV3_18S";
+
+    case(IDDIGITIZERV3_20S): return "IDDIGITIZERV3_20S";
+    case(IDDIGITIZERV3_22S): return "IDDIGITIZERV3_22S";
+    case(IDDIGITIZERV3_24S): return "IDDIGITIZERV3_24S";
+    case(IDDIGITIZERV3_26S): return "IDDIGITIZERV3_26S";
+    case(IDDIGITIZERV3_28S): return "IDDIGITIZERV3_28S";
+
+    case(IDDIGITIZERV3_30S): return "IDDIGITIZERV3_30S";
+
     case(IDHAMMOND): return "IDHAMMOND";
     case(IDSAM): return "IDSAM";
     case(IDDCFEM): return "IDDCFEM";


### PR DESCRIPTION
This packaging and wrapping up Dan's work on the new decoder for the 160++ hitformats. We assigned them so that the hitformat is 160 + nr_of_samples, so for 12 samples we get 172. 
This is better than for the old data format where the hitformats were assigned differently, and we only supported 12, 16, and 31 samples. This supports any valid sample number. Note that the sample nr needs to be even, so we can have 2,4,6,....,30. 