### PR TITLE
speed-up of TPC decoding

### DIFF
--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -97,10 +97,12 @@ struct bco_compare {
   waveform_set waveforms;
   //  waveform_set waveforms[MAX_FEECOUNT * MAX_CHANNELS];
 
+  std::vector<sampa_waveform*> waveform_vector;
+  
   int cacheIterator(const int n);
   
-  waveform_set::iterator _cached_iter;
   int _last_requested_element;
+  sampa_waveform* _last_requested_waveform;
   
   std::vector<unsigned short> fee_data[MAX_FEECOUNT];
 


### PR DESCRIPTION
The current official version of the "cachedIterator" had a stupid bug that prevented it from actually caching the earlier result, so for every query it would make a full iterator search. That fix made about a factor of 60 difference. I then streamlined the decoding further and gained about a factor of 70 in speed overall. Here is the result of a 100-event ddump before and after:

```
$ time ddump  -n 100 /data/tpc/TPC_ebdc00_beam-00021560-0000.prdf > /dev/null
real    6m24.404s
user    6m23.380s
sys     0m1.004s
```
After the first fix:

```
$ time ddump  -n 100 /data/tpc/TPC_ebdc00_beam-00021560-0000.prdf > /dev/null

real    0m6.458s
user    0m5.573s
sys     0m0.884s
```

With the current version:

```
$ time ddump  -n 100 /data/tpc/TPC_ebdc00_beam-00021560-0000.prdf > /dev/null```

real    0m5.465s
user    0m4.614s
sys     0m0.849s
```

Note that this fix needs to be back-ported to the TPC pool class. I suggest that we stay with the direct packet interface for a few more days. 