### PR TITLE
fixes to the checksum interfaces for the new zero-suppressed digitizer formats

### DIFF
--- a/newbasic/oncsSub_idcaenv1742.cc
+++ b/newbasic/oncsSub_idcaenv1742.cc
@@ -233,7 +233,7 @@ int oncsSub_idcaenv1742::iValue(const int n,const char *what)
     return freq;
   }
 
-  if ( strcmp(what,"GROUPMASK") == 0 )
+  if ( strcmp(what,"GROUPPRESENT") == 0 )
   {
     if ( n <0 || n >=4) return 0;
     return (group_mask >> n) &1;
@@ -273,10 +273,10 @@ void  oncsSub_idcaenv1742::dump ( OSTREAM& os )
     }
   os << "("<< f << ")" << std::endl;
 
-  os << "Group Mask:              ";
+  os << "Group present:           ";
   for ( i = 0; i < 4; i++)
     {
-      os<< iValue(i, "GROUPMASK") << "  ";
+      os<< iValue(i, "GROUPPRESENT") << "  ";
     }
   os << std::endl;
 

--- a/newbasic/oncsSub_idcaenv1742.cc
+++ b/newbasic/oncsSub_idcaenv1742.cc
@@ -233,6 +233,12 @@ int oncsSub_idcaenv1742::iValue(const int n,const char *what)
     return freq;
   }
 
+  if ( strcmp(what,"GROUPMASK") == 0 )
+  {
+    if ( n <0 || n >=4) return 0;
+    return (group_mask >> n) &1;
+  }
+
   return 0;
 
 }
@@ -266,6 +272,14 @@ void  oncsSub_idcaenv1742::dump ( OSTREAM& os )
       break;
     }
   os << "("<< f << ")" << std::endl;
+
+  os << "Group Mask:              ";
+  for ( i = 0; i < 4; i++)
+    {
+      os<< iValue(i, "GROUPMASK") << "  ";
+    }
+  os << std::endl;
+
 
   os << "contains trigger sample: ";
   for ( i = 0; i < 4; i++)

--- a/newbasic/packet_iddigitizerv2.cc
+++ b/newbasic/packet_iddigitizerv2.cc
@@ -295,6 +295,17 @@ int Packet_iddigitizerv2::iValue(const int n, const char *what)
       return 0;
     }
 
+  if ( strcmp(what,"CHECKSUMOK") == 0 )
+  {
+    if (  _calculated_odd_checksum < 0 ) return -1; // cannot evaluate
+    if (  _calculated_even_checksum < 0 ) return -1; // cannot evaluate
+    if (  _even_checksum == _calculated_even_checksum  &&  _odd_checksum == _calculated_odd_checksum) return 1;
+
+    return 0;
+
+  }
+
+  
   return 0;
 
 }

--- a/newbasic/packet_iddigitizerv3.cc
+++ b/newbasic/packet_iddigitizerv3.cc
@@ -27,6 +27,7 @@ Packet_iddigitizerv3::Packet_iddigitizerv3(PACKET_ptr data)
   _detid = 0;
   _module_address  = 0;
   _xmit_clock = 0;
+  _AnyChannelisSuppressed = false;  // we use this later to see if the checksum can be calculated
   
   for ( int i = 0; i < NR_FEMS; i++)
     {
@@ -173,6 +174,7 @@ unsigned int Packet_iddigitizerv3::decode_FEM ( unsigned int *k, const int fem_n
 	{
 	  corrected_index_channel = index_channel^1;
 	  isZeroSuppressed[corrected_index_channel] = true;
+	  _AnyChannelisSuppressed = true;
 	  pre_post[0][corrected_index_channel] = (k[index] & 0x3fff);
 	  pre_post[1][corrected_index_channel] = ((k[index]>>14) & 0x3fff);
 	  // coutfl << " found a zp-word  " << hex << "0x" << k[index]  << dec << " at index " << index
@@ -353,6 +355,23 @@ int Packet_iddigitizerv3::iValue(const int n, const char *what)
     return _fem_calculated_checksum_LSB[n];
   }
 
+  // to maintain compatibility with v2, we provide those interfaces
+  // but we return -1 for "cannot be determined"
+  if ( strcmp(what,"EVENCHECKSUMOK") == 0 )
+  {
+    return -1;
+  }
+
+  if ( strcmp(what,"ODDCHECKSUMOK") == 0 )
+  {
+    return -1;
+  }
+  
+  if ( strcmp(what,"CHECKSUMOK") == 0 )
+  {
+    return -1;
+  }
+  
   if ( strcmp(what,"PRE") == 0 )
   {
     if ( n < 0 || n >= _nchannels ) return 0;

--- a/newbasic/packet_iddigitizerv3.h
+++ b/newbasic/packet_iddigitizerv3.h
@@ -51,6 +51,7 @@ protected:
   int _is_decoded;
 
   bool isZeroSuppressed[NR_FEMS*64];
+  bool _AnyChannelisSuppressed;
 
   int adc[32][NR_FEMS*64];
   int pre_post[2][NR_FEMS*64];


### PR DESCRIPTION
With the digitizer decoders so far we had interfaces "EVENCHECKSUMOK" and "ODDCHECKSUMOK" that would show the checksum status for the even and odd channels. Due to the hardware design, those are calculated independently. With the advent of the new zero-suppressed formats where those checksums don't exist, this interface returned 0, interpreted as "wrong checksum". 

For backward-compatibility, I added those interfaces that always return -1, meaning "cannot be determined". 

I have implemented a more generic interface "CHECKSUMOK" that works for all hitformats. Let's retire the old "odd" and "even" checks in favor of this one. 

Keep in mind that all checksum interfaces have a "tri-state" output:
 1 - checksum is ok
 0 - checksum is wrong
-1 - checksum cannot be evaluated.

Each time we have a zero-suppressed packet, it is not possible to re-calculate the checksum  for comparison, so in the vast majority of cases we see a -1. 

