### PR TITLE
initialize status to make clang happy

### DIFF
--- a/newbasic/eventServer.cc
+++ b/newbasic/eventServer.cc
@@ -145,7 +145,7 @@ main(int argc, char *argv[])
   int c;
 
 
-  int status;
+  int status = -1;
 
   pthread_mutex_init( &MapSem, 0);
 


### PR DESCRIPTION
clang complains about an uninitialized variable. It's a this will never happen case but clang doesn't know