### PR TITLE
in the quest to eventually phase out the "newbasic" name, I added an "eventlibraries" symlink

### DIFF
--- a/eventlibraries
+++ b/eventlibraries
@@ -1,0 +1,1 @@
+newbasic


### PR DESCRIPTION
We got derailed with changing the ugly name "newbasic" that predates git to "eventlibraries". This new name has already been documented in the manual for a while. In 2020 we had back out of the name change due to too many automated installation scripts breaking. This is easing us into the name change in a gentle way.