### PR TITLE
ycm - add pValue function which return pointer to packet data

### DIFF
--- a/newbasic/oncsSub_idmvtxv3.cc
+++ b/newbasic/oncsSub_idmvtxv3.cc
@@ -368,6 +368,18 @@ long long int oncsSub_idmvtxv3::lValue(const int i_feeid, const int idx, const c
 
 
 //_________________________________________________
+void * oncsSub_idmvtxv3::pValue(const int channel)
+{
+  if (channel == getIdentifier())
+  {
+    return &SubeventHdr->data;
+  }
+
+  return nullptr;
+}
+
+
+//_________________________________________________
 void oncsSub_idmvtxv3::dump(OSTREAM &os)
 {
   identify(os);

--- a/newbasic/oncsSub_idmvtxv3.h
+++ b/newbasic/oncsSub_idmvtxv3.h
@@ -31,6 +31,8 @@ class  oncsSub_idmvtxv3 : public  oncsSubevent_w4 {
 
   long long int lValue(const int, const int, const char* what) final;
 
+  void * pValue(const int) final;
+
   void dump(OSTREAM &os = COUT) final;
 
  protected:


### PR DESCRIPTION
This PR introduce a method to get initial packet data pointer which is used to direct pooling data in the mvdx decoder. 