### PR TITLE
added a new "lastEvent" utility that can efficiently find the last event in a raw data file

### DIFF
--- a/newbasic/oncsSubevent.cc
+++ b/newbasic/oncsSubevent.cc
@@ -126,7 +126,7 @@ int oncsSubevent::convert()
 }
 
 
-// ------------------------------------------------------
+//------------------------------------------------------
 
 int   oncsSubevent::iValue(const int ich)
 {
@@ -139,7 +139,7 @@ int   oncsSubevent::iValue(const int ich)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return decoded_data1[ich];
 }
@@ -157,7 +157,7 @@ int   oncsSubevent::iValue(const int ich, const char *what)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return decoded_data1[ich];
 }
@@ -175,7 +175,7 @@ int   oncsSubevent::iValue(const int ich, const int iy)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return decoded_data1[ich];
 }
@@ -193,7 +193,7 @@ float oncsSubevent::rValue(const int ich)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return float(decoded_data1[ich]);
 }
@@ -211,7 +211,7 @@ float oncsSubevent::rValue(const int ich, const char *what)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return float(decoded_data1[ich]);
 }
@@ -229,7 +229,7 @@ float oncsSubevent::rValue(const int ich, const int iy)
     }
 
   // see if our array is long enough
-  if (ich > data1_length) return 0;
+  if (ich >= data1_length) return 0;
 
   return float(decoded_data1[ich]);
 }


### PR DESCRIPTION
So far, the only way to find the last event in a file was to traverse the entire file (because files are in all other contexts treated as non-direct-access streams). This utility adds an efficient way to get at the last event(s) in a file, which in sPHENIX is needed in several contexts. It goes to the end of the file and works its way backwards to the beginning of a new buffer. It so gets fast access to the last few events in that buffer. In a single-file run, this is usually the end-run event:
```
lastEvent   /mac_home/data/V1742/rcdaq-00000003-0000.evt
 -- Event    20 Run:     3 length:     8 type: 12 (End Run Event)  1515015411
```
but with file rollover this is not normally the case.

Options (lastEvent -h):

```
lastEvent finds the last event(s) in a given file in an efficient way.
  List of options:
  -n <number> show the last n events. At most the number of events in the last buffer will be shown.
  -i identify the event (default unless -d is given)
  -d dump this event
  -l list the packets (as in dlist)
  -p dump these packet ids - same selections as with ddump
```

