### PR TITLE
Modified decoder that works consistently with non-ZS and ZS mode

### DIFF
--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -206,17 +206,33 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 		| (header[1] >> 9);	  
 
 	      // now we add the actual waveform
-	      unsigned short data_size = header[5] -1 ;
+	     // unsigned short data_size = header[5] -1 ;
+	      short data_size_counter = header[0]-5;
 
 	     //  coutfl << " Fee: " << ifee << " Sampa " << sw->sampa_address
 	     //  	 << " sampa channel: " << sw->sampa_channel
 	     //  	 << " channel: " << sw->channel
 	     //  	 << "  waveform length: " << data_size  << endl;
 
-	      for (int i = 0 ; i < data_size ; i++)
+	     // for (int i = 0 ; i < data_size ; i++)
+	      // First fill -100 for all time samples
+	      for (int i = 0 ; i < 1024 ; i++)
 		{
-		  sw->waveform.push_back( fee_data[ifee][pos++]);
+		  sw->waveform.push_back(-100);
 		}
+
+	      // Format is (N sample) (start time), (1st sample)... (Nth sample)
+	      for (int i = 0 ; i < header[0]-5 ; i++)
+		{
+		  int nsamp = fee_data[ifee][pos++];
+		  int start_t = fee_data[ifee][pos++];
+		  data_size_counter-=2;
+		  for (int j=0; j<nsamp;j++){
+		      sw->waveform[start_t+j]= fee_data[ifee][pos++]; 
+		      data_size_counter--;
+		  }
+		}
+	      if (data_size_counter<0) cout <<" error in datasize"<<endl;
 	      
 	      // we calculate the checksum here because "pos" is at the right place
 	      unsigned short crc = crc16(ifee, startpos, header[0]-1);

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -219,18 +219,24 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 	      for (int i = 0 ; i < 1024 ; i++)
 		{
 		  sw->waveform.push_back(-100);
+//		cout <<"Initializing waveform "<<i<<endl;
 		}
 
 	      // Format is (N sample) (start time), (1st sample)... (Nth sample)
-	      for (int i = 0 ; i < header[0]-5 ; i++)
+	      //for (int i = 0 ; i < header[0]-5 ; i++)
+	      while(data_size_counter>0)
 		{
 		  int nsamp = fee_data[ifee][pos++];
 		  int start_t = fee_data[ifee][pos++];
 		  data_size_counter-=2;
+                  cout<<"nsamp: "<<nsamp<<" ";
+                  cout<<"start_t: "<<start_t<<" ";
+		  if(nsamp>data_size_counter+2){ cout<<"format error"<<endl; break;}
 		  for (int j=0; j<nsamp;j++){
 		      sw->waveform[start_t+j]= fee_data[ifee][pos++]; 
 		      data_size_counter--;
 		  }
+                  cout<<"data_size_counter: "<<data_size_counter<<" "<<endl;
 		}
 	      if (data_size_counter<0) cout <<" error in datasize"<<endl;
 	      

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -196,8 +196,8 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 	      sampa_waveform *sw = new sampa_waveform;
 	  
 	      sw->fee           = ifee;
-	      sw->pkt_length    = header[0];
-	      sw->adc_length    = header[5];
+	      sw->pkt_length    = header[0]; // this is indeed the number of 10-bit words + 5 in this packet
+	      sw->adc_length    = header[0]-5; // this is indeed the number of 10-bit words in this packet
 	      sw->sampa_address = (header[1] >> 5) & 0xf;
 	      sw->sampa_channel = header[1] & 0x1f;
 	      sw->channel       = header[1] & 0x1ff;
@@ -466,7 +466,8 @@ int oncsSub_idtpcfeev3::find_header ( const unsigned int yy,  const std::vector<
     {
       //      coutfl << " current pos is  " << pos  << "  vector length " << orig.size()  << endl;
 	    
-      if (header_candidate[4] == MAGIC_KEY_0 && header_candidate[6] == MAGIC_KEY_1 && (header_candidate[0] - header_candidate[5] == HEADER_LENGTH))
+//      if (header_candidate[4] == MAGIC_KEY_0 && header_candidate[6] == MAGIC_KEY_1 && (header_candidate[0] - header_candidate[5] == HEADER_LENGTH))
+      if (header_candidate[4] == MAGIC_KEY_0)
 	{
 	  // found it!
             found = true;

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -218,7 +218,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 	      // First fill -100 for all time samples
 	      for (int i = 0 ; i < 1024 ; i++)
 		{
-		  sw->waveform.push_back(-100);
+		  sw->waveform.push_back(65000);
 //		cout <<"Initializing waveform "<<i<<endl;
 		}
 
@@ -229,27 +229,43 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 		  int nsamp = fee_data[ifee][pos++];
 		  int start_t = fee_data[ifee][pos++];
 		  data_size_counter-=2;
-                  cout<<"nsamp: "<<nsamp<<" ";
-                  cout<<"start_t: "<<start_t<<" ";
-		  if(nsamp>data_size_counter+2){ cout<<"format error"<<endl; break;}
+//                  cout<<"nsamp: "<<nsamp<<" ";
+//                  cout<<"start_t: "<<start_t<<" ";
+		  if(nsamp>data_size_counter){ cout<<"nsamp: "<<nsamp<<", size: "<<data_size_counter<<", format error"<<endl; break;}
 		  for (int j=0; j<nsamp;j++){
 		      sw->waveform[start_t+j]= fee_data[ifee][pos++]; 
+//                   cout<<"data: "<< sw->waveform[start_t+j]<<endl;
 		      data_size_counter--;
+
+	      //
+	      // This line is inserted to accommodate the "wrong format issue", which is the
+	      // last sample from the data is missing. This issue should be fixed and eventually
+	      // the following two lines will be removed
+	      //
+		      if(data_size_counter==1) break;
 		  }
-                  cout<<"data_size_counter: "<<data_size_counter<<" "<<endl;
+//                  cout<<"data_size_counter: "<<data_size_counter<<" "<<endl;
+		      if(data_size_counter==1) break;
 		}
 	      if (data_size_counter<0) cout <<" error in datasize"<<endl;
+
 	      
 	      // we calculate the checksum here because "pos" is at the right place
 	      unsigned short crc = crc16(ifee, startpos, header[0]-1);
 	      // coutfl << "fee " << setw(3) << sw->fee
 	      // 	     << " sampla channel " << setw(3) <<  sw->channel
 	      // 	     << " crc and value " << hex << setw(5) << crc << " " << setw(5) << fee_data[ifee][pos] << dec;
-	      // if (  crc != fee_data[ifee][pos] ) cout << "  *********";
-	      // cout << endl;
+//	       if (  crc != fee_data[ifee][pos] ) cout << "  *********";
+
+//	       if (  crc != fee_data[ifee][pos-1] ) cout << "crc: "<<crc<<", fee: "<<fee_data[ifee][pos-1]<<endl;
+	       if (  crc != fee_data[ifee][pos] ) cout << "crc: "<<crc<<", fee: "<<fee_data[ifee][pos]<<endl;
+
 	      
 	      sw->checksum = crc;
+
 	      sw->valid = ( crc == fee_data[ifee][pos]);
+
+//	      sw->valid = ( crc == fee_data[ifee][pos-1]);
 	      
 	      waveforms.insert(sw);
 	    }

--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -240,12 +240,12 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 	      //
 	      // This line is inserted to accommodate the "wrong format issue", which is the
 	      // last sample from the data is missing. This issue should be fixed and eventually
-	      // the following two lines will be removed
+	      // the following two lines will be removed. Apr 30. by TS
 	      //
 		      if(data_size_counter==1) break;
-		  }
+		    }
 //                  cout<<"data_size_counter: "<<data_size_counter<<" "<<endl;
-		      if(data_size_counter==1) break;
+	          if(data_size_counter==1) break;
 		}
 	      if (data_size_counter<0) cout <<" error in datasize"<<endl;
 
@@ -258,6 +258,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 //	       if (  crc != fee_data[ifee][pos] ) cout << "  *********";
 
 //	       if (  crc != fee_data[ifee][pos-1] ) cout << "crc: "<<crc<<", fee: "<<fee_data[ifee][pos-1]<<endl;
+
 	       if (  crc != fee_data[ifee][pos] ) cout << "crc: "<<crc<<", fee: "<<fee_data[ifee][pos]<<endl;
 
 	      
@@ -265,8 +266,6 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 
 	      sw->valid = ( crc == fee_data[ifee][pos]);
 
-//	      sw->valid = ( crc == fee_data[ifee][pos-1]);
-	      
 	      waveforms.insert(sw);
 	    }
 	  

--- a/newbasic/oncsSub_idtpcfeev3.h
+++ b/newbasic/oncsSub_idtpcfeev3.h
@@ -40,7 +40,7 @@ protected:
 
   static const unsigned short  MAX_FEECOUNT = 26;   // that many FEEs
   static const unsigned short  MAX_CHANNELS   = 8*32; // that many channels per FEE
-  static const unsigned short  HEADER_LENGTH  = 7;
+  static const unsigned short  HEADER_LENGTH  = 5;
   
   unsigned short reverseBits(const unsigned short x) const;
   unsigned short crc16(const unsigned int fee, const unsigned int index, const int  l) const;


### PR DESCRIPTION
The decoder was modified so that it works both for non-ZS and ZS mode. 

![TPC_FEE_data format_forpush_Apr30](https://github.com/sPHENIX-Collaboration/online_distribution/assets/23665996/ae77f382-3468-42fb-bf55-d45dd46e160b)

Until the N'th sample missing issue is fixed and additional sync word is added, the data format will be kept as it is.