### PR TITLE
mlp - I added the "EVTNR" as an lValue

### DIFF
--- a/newbasic/packet_iddigitizerv3.cc
+++ b/newbasic/packet_iddigitizerv3.cc
@@ -280,6 +280,12 @@ long long Packet_iddigitizerv3::lValue(const int n, const char *what)
   {
     return _xmit_clock;
   }
+
+  if ( strcmp(what,"EVTNR") == 0 )
+  {
+    return _evtnr;
+  }
+
   return 0;
 }
 
@@ -414,7 +420,7 @@ void  Packet_iddigitizerv3::dump ( OSTREAM& os )
       return;
     }
   
-  os << "Evt Nr:      " << iValue(0,"EVTNR") << std::endl;
+  os << "Evt Nr:      " << lValue(0,"EVTNR") << std::endl;
   os << "Clock:       " << lValue(0,"CLOCK") << std::endl;
   os << "Nr Modules:  " << iValue(0,"NRMODULES") << std::endl;
   os << "Channels:    " << iValue(0,"CHANNELS") << std::endl;


### PR DESCRIPTION
more out of a sense of completeness, I added the "EVTNR" as an lValue as well.

however, since the event number is really unlikely to run past 4 billion, here I left the iValue intact. So you get the same value.