### PR TITLE
fixed memory leak

### DIFF
--- a/newbasic/oncsSub_idtpcfeev3.cc
+++ b/newbasic/oncsSub_idtpcfeev3.cc
@@ -284,6 +284,7 @@ int oncsSub_idtpcfeev3::tpc_decode ()
 
 	          waveforms.insert(sw);
 	       }
+               else{ delete sw; }
 	    }
 	  
 	  //coutfl << "inserting at " << ifee*MAX_CHANNELS + sw->channel << " size is " << waveforms.size() << endl;


### PR DESCRIPTION
Implemented deleting sampa waveform class in case the data didn't pass the length consistency check.