### PR TITLE
Memory error fixes on `oncsSub_idtpcfeev4`

### DIFF
--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -242,11 +242,21 @@ int oncsSub_idtpcfeev4::tpc_decode ()
 //		  if(nsamp>data_size_counter){ cout<<"nsamp: "<<nsamp<<", size: "<<data_size_counter<<", format error"<<endl; break;}
 
 		  for (int j=0; j<nsamp;j++){
+
+          if (pos>= fee_data[ifee].size())
+          {
+            std::cout<<__PRETTY_FUNCTION__<<" : warning - sampa data wavelet loss at the end of fee_data.for fee "<<ifee<<std::endl;
+            continue;
+          }
                       if(start_t+j<1024){ sw->waveform[start_t+j]= fee_data[ifee][pos++]; }
                       else { pos++; }
 //                   cout<<"data: "<< sw->waveform[start_t+j]<<endl;
 		      data_size_counter--;
 		    }
+          if (pos>= fee_data[ifee].size())
+          {
+            continue;
+          }
 		}
 
 	      //

--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -186,7 +186,7 @@ int oncsSub_idtpcfeev4::tpc_decode ()
 	  unsigned int startpos = pos;
 
 	  // first the check if our vector cuts off before the fixed-length header, then we are already done
-	  if ( startpos + HEADER_LENGTH >= fee_data[ifee].size() || startpos + fee_data[ifee][startpos] > fee_data[ifee].size())
+	  if ( startpos + HEADER_LENGTH >= fee_data[ifee].size() || startpos + fee_data[ifee][startpos] >= fee_data[ifee].size())
 	    {
 	      pos = fee_data[ifee].size() + 1; // make sure we really terminate the loop
 	    }

--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -245,8 +245,8 @@ int oncsSub_idtpcfeev4::tpc_decode ()
 
           if (pos>= fee_data[ifee].size())
           {
-            std::cout<<__PRETTY_FUNCTION__<<" : warning - sampa data wavelet loss at the end of fee_data.for fee "<<ifee<<std::endl;
-            continue;
+            // std::cout<<__PRETTY_FUNCTION__<<" : warning - sampa data wavelet loss at the end of fee_data for fee "<<ifee<<std::endl;
+            break;
           }
                       if(start_t+j<1024){ sw->waveform[start_t+j]= fee_data[ifee][pos++]; }
                       else { pos++; }

--- a/newbasic/oncsSub_idtpcfeev4.h
+++ b/newbasic/oncsSub_idtpcfeev4.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <algorithm>
 #include <functional>
+#include <limits>
 
 #ifndef __CINT__
 class WINDOWSEXPORT oncsSub_idtpcfeev4 : public  oncsSubevent_w2 {
@@ -58,20 +59,20 @@ protected:
   int _is_decoded;
 
   struct sampa_waveform {
-    unsigned short fee;
-    unsigned short pkt_length;
-    unsigned short channel;
-    unsigned short sampa_channel;
-    unsigned short sampa_address;
-    unsigned int bx_timestamp;
+    unsigned short fee = std::numeric_limits<unsigned short>::max();
+    unsigned short pkt_length = std::numeric_limits<unsigned short>::max();
+    unsigned short channel = std::numeric_limits<unsigned short>::max();
+    unsigned short sampa_channel = std::numeric_limits<unsigned short>::max();
+    unsigned short sampa_address = std::numeric_limits<unsigned short>::max();
+    unsigned int bx_timestamp = 0;
     std::vector<unsigned short> waveform;
-    unsigned short adc_length;
-    unsigned short checksum;
-    unsigned short user_word;
-    unsigned short type;
-    unsigned short data_parity;
-    bool     valid;
-    bool     parity_valid;
+    unsigned short adc_length = std::numeric_limits<unsigned short>::max();
+    unsigned short checksum = std::numeric_limits<unsigned short>::max();
+    unsigned short user_word = std::numeric_limits<unsigned short>::max();
+    unsigned short type = std::numeric_limits<unsigned short>::max();
+    unsigned short data_parity = std::numeric_limits<unsigned short>::max();
+    bool     valid = false;
+    bool     parity_valid = false;
   };
 
   struct gtm_payload {


### PR DESCRIPTION
This is aimed to fix memory errors identified in the Continuous Integration checks: 
https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-default-valgrind-StreamingProduction/386/valgrindResult/pid=323555/ 

1. Some FEE data buffer could go out of bound SAMPA data packet at the edge of the RCDAQ events: https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-default-valgrind-StreamingProduction/386/valgrindResult/pid=323555,0x1a3d/ 
2. Unconditional jump on uninitialized variables due to they are not always filled in decoder: https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-default-valgrind-StreamingProduction/386/valgrindResult/pid=323555,0x9e7/

