### PR TITLE
mlp - added support of a 2nd variant of LZO (LZO1C in addition to LZO1X)

### DIFF
--- a/newbasic/BufferConstants.h
+++ b/newbasic/BufferConstants.h
@@ -6,10 +6,11 @@
 #define EOBLENGTH 4U
 #define BUFFERSIZE (1024U*1024U)
 
-#define BUFFERMARKER      0xffffffc0U
-#define ONCSBUFFERMARKER  0xffffc0c0U
-#define GZBUFFERMARKER    0xfffffafeU
-#define LZO1XBUFFERMARKER 0xffffbbfeU
+#define BUFFERMARKER          0xffffffc0U
+#define ONCSBUFFERMARKER      0xffffc0c0U
+#define GZBUFFERMARKER        0xfffffafeU
+#define LZO1XBUFFERMARKER     0xffffbbfeU
+#define LZO1CBUFFERMARKER     0xffffbcfeU
 #define ONCSLZO1XBUFFERMARKER 0xffffbbc0U
 
 #define BUFFERBLOCKSIZE 8192U

--- a/newbasic/buffer.cc
+++ b/newbasic/buffer.cc
@@ -23,7 +23,8 @@ int buffer::makeBuffer( PHDWORD *bp, const int allocatedsize, buffer **bptr)
       return 0;
     }
 
-  else if ( bp[1]== LZO1XBUFFERMARKER || buffer::u4swap(bp[1])== LZO1XBUFFERMARKER )
+  else if ( bp[1]== LZO1XBUFFERMARKER || buffer::u4swap(bp[1])== LZO1XBUFFERMARKER 
+	    || bp[1]== LZO1CBUFFERMARKER || buffer::u4swap(bp[1])== LZO1CBUFFERMARKER  )
     {
       *bptr = new lzobuffer ( bp, allocatedsize );
       return 0;

--- a/newbasic/fileEventiterator.cc
+++ b/newbasic/fileEventiterator.cc
@@ -192,14 +192,14 @@ int fileEventiterator::read_next_buffer()
 
       // get the buffer length into a dedicated variable
       if (initialbuffer[1] == BUFFERMARKER || initialbuffer[1]== GZBUFFERMARKER 
-	  ||  initialbuffer[1]== LZO1XBUFFERMARKER || initialbuffer[1]== ONCSBUFFERMARKER) 
+	  ||  initialbuffer[1]== LZO1XBUFFERMARKER || initialbuffer[1]== LZO1CBUFFERMARKER || initialbuffer[1]== ONCSBUFFERMARKER) 
 	{
 	  buffer_size = initialbuffer[0];
 	}
       else
 	{
 	  unsigned int  marker = buffer::u4swap(initialbuffer[1]);
-	  if (marker == BUFFERMARKER || marker == GZBUFFERMARKER || marker ==  LZO1XBUFFERMARKER || marker == ONCSBUFFERMARKER)
+	  if (marker == BUFFERMARKER || marker == GZBUFFERMARKER || marker ==  LZO1XBUFFERMARKER || marker ==  LZO1CBUFFERMARKER || marker == ONCSBUFFERMARKER)
 	    {
 	      buffer_size = buffer::u4swap(initialbuffer[0]);
 	    }
@@ -259,7 +259,9 @@ int fileEventiterator::read_next_buffer()
   if ( ( initialbuffer[1]== GZBUFFERMARKER || 
        buffer::u4swap(initialbuffer[1])== GZBUFFERMARKER ||
        initialbuffer[1]== LZO1XBUFFERMARKER || 
-       buffer::u4swap(initialbuffer[1])== LZO1XBUFFERMARKER )
+       buffer::u4swap(initialbuffer[1])== LZO1XBUFFERMARKER ||
+       initialbuffer[1]== LZO1CBUFFERMARKER || 
+       buffer::u4swap(initialbuffer[1])== LZO1CBUFFERMARKER )
        && errorinread  )
     {
       bptr = 0;

--- a/newbasic/lastEvent.cc
+++ b/newbasic/lastEvent.cc
@@ -192,14 +192,14 @@ main(int argc, char *argv[])
 
       // get the buffer length into a dedicated variable
       if (initialbuffer[1] == BUFFERMARKER || initialbuffer[1]== GZBUFFERMARKER 
-	  ||  initialbuffer[1]== LZO1XBUFFERMARKER || initialbuffer[1]== ONCSBUFFERMARKER) 
+	  ||  initialbuffer[1]== LZO1XBUFFERMARKER || initialbuffer[1]== LZO1CBUFFERMARKER ||initialbuffer[1]== ONCSBUFFERMARKER) 
 	{
 	  buffer_size = initialbuffer[0];
 	}
       else
 	{
 	  unsigned int  marker = buffer::u4swap(initialbuffer[1]);
-	  if (marker == BUFFERMARKER || marker == GZBUFFERMARKER || marker ==  LZO1XBUFFERMARKER || marker == ONCSBUFFERMARKER)
+	  if (marker == BUFFERMARKER || marker == GZBUFFERMARKER || marker ==  LZO1XBUFFERMARKER || initialbuffer[1]== LZO1CBUFFERMARKER || marker == ONCSBUFFERMARKER)
 	    {
 	      buffer_size = buffer::u4swap(initialbuffer[0]);
 	    }

--- a/newbasic/lzobuffer.cc
+++ b/newbasic/lzobuffer.cc
@@ -28,12 +28,12 @@ lzobuffer::lzobuffer (PHDWORD *array , const int length )
 
   lzo_uint bytes; 
   lzo_uint outputlength_in_bytes;
-  if (array[1] == LZO1XBUFFERMARKER )
+  if (array[1] == LZO1XBUFFERMARKER || array[1] == LZO1CBUFFERMARKER)
     {
       bytes = array[0]-4*BUFFERHEADERLENGTH;
       outputlength_in_bytes = array[3];
     }
-  else if ( u4swap(array[1]) == LZO1XBUFFERMARKER)
+  else if ( u4swap(array[1]) == LZO1XBUFFERMARKER || u4swap(array[1]) == LZO1CBUFFERMARKER)
     {
       bytes = i4swap(array[0])-16;
       outputlength_in_bytes = i4swap(array[3]);
@@ -41,7 +41,7 @@ lzobuffer::lzobuffer (PHDWORD *array , const int length )
 
   else
     {
- 	COUT << " wrong buffer" << std::endl;
+      COUT << __FILE__ << " " << __LINE__ << " wrong buffer marker = " << std::hex << array[1] << std::dec << std::endl;
 	is_good = 0;
 	return;
     }
@@ -53,9 +53,19 @@ lzobuffer::lzobuffer (PHDWORD *array , const int length )
 
   //  std::cout << __FILE__ << "  " << __LINE__ << " safe!!! array length before is " << array[-1] << std::endl;
   olen = outputlength_in_bytes;
-  lzo1x_decompress_safe ( (lzo_byte *)  &array[4], bytes,
-  		     (lzo_byte *)  bufferarray, &olen, NULL );
-  
+
+  if (array[1] == LZO1XBUFFERMARKER || u4swap(array[1]) == LZO1XBUFFERMARKER )
+    {
+      lzo1x_decompress_safe ( (lzo_byte *)  &array[4], bytes,
+			      (lzo_byte *)  bufferarray, &olen, NULL );
+    }
+  else
+    {
+
+      lzo1c_decompress_safe ( (lzo_byte *)  &array[4], bytes,
+			      (lzo_byte *)  bufferarray, &olen, NULL );
+
+    }
 
   //  std::cout << __FILE__ << "  " << __LINE__ << " array length after is " << array[-1] << std::endl;
 

--- a/newbasic/lzobuffer.h
+++ b/newbasic/lzobuffer.h
@@ -3,6 +3,7 @@
 
 #include "prdfBuffer.h"
 #include <lzo/lzo1x.h>
+#include <lzo/lzo1c.h>
 
 
 #ifndef __CINT__

--- a/newbasic/prdfcheck.cc
+++ b/newbasic/prdfcheck.cc
@@ -54,14 +54,17 @@ main(int argc, char *argv[])
 	   buffer[1] == GZBUFFERMARKER || 
 	   buffer::u4swap(buffer[1]) ==  GZBUFFERMARKER ||
 	   buffer[1] == LZO1XBUFFERMARKER || 
-	   buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER )
+	   buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER ||
+	   buffer[1] == LZO1CBUFFERMARKER || 
+	   buffer::u4swap(buffer[1]) == LZO1CBUFFERMARKER )
 	{
 
 
 	  if ( buffer::u4swap(buffer[1]) == BUFFERMARKER || 
 	       buffer::u4swap(buffer[1]) == ONCSBUFFERMARKER ||
 	       buffer::u4swap(buffer[1]) == GZBUFFERMARKER ||
-	       buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER )
+	       buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER ||
+	       buffer::u4swap(buffer[1]) == LZO1CBUFFERMARKER )
 	    {
 	      needs_swap = 1;
 	    }
@@ -97,7 +100,9 @@ main(int argc, char *argv[])
  	  else if ( buffer[1] == GZBUFFERMARKER || 
 		    buffer::u4swap(buffer[1]) == GZBUFFERMARKER ) std::cout << "GZIP Marker" << std::endl;
 	  else if ( buffer[1] == LZO1XBUFFERMARKER || 
-		    buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER ) 
+		    buffer::u4swap(buffer[1]) == LZO1XBUFFERMARKER ||
+		    buffer[1] == LZO1CBUFFERMARKER || 
+		    buffer::u4swap(buffer[1]) == LZO1CBUFFERMARKER ) 
 	    {
 	      std::cout << "LZO Marker ";
 	      std::cout << " Or.length: " << buffer[3];

--- a/newbasic/prdfsplit.cc
+++ b/newbasic/prdfsplit.cc
@@ -30,14 +30,16 @@ int check_buffermarker ( const unsigned int bm)
   
   if ( bm == BUFFERMARKER || 
        bm == GZBUFFERMARKER || 
-       bm == LZO1XBUFFERMARKER )
+       bm == LZO1XBUFFERMARKER ||
+       bm == LZO1CBUFFERMARKER )
     {
       return 1;
     }
   
   else if ( buffer::u4swap(bm) == BUFFERMARKER || 
 	    buffer::u4swap(bm) == GZBUFFERMARKER ||
-	    buffer::u4swap(bm) == LZO1XBUFFERMARKER )
+	    buffer::u4swap(bm) == LZO1XBUFFERMARKER ||
+	    buffer::u4swap(bm) == LZO1CBUFFERMARKER )
     {
       return -1;
     }


### PR DESCRIPTION
I'm enabling a 2nd strain of LZO compression algorithms in the DAQ. This adds support for dealing with this in the event libs.