### PR TITLE
mlp - added the desired APIs to get the FEEs per BCO out of a packet.

### DIFF
--- a/newbasic/oncsSub_idinttv0.h
+++ b/newbasic/oncsSub_idinttv0.h
@@ -4,6 +4,7 @@
 #include "oncsSubevent.h"
 #include <vector>
 #include <set>
+#include <map>
 #include <algorithm>
 #include <functional>
 #include <stdint.h>
@@ -65,7 +66,10 @@ protected:
   std::vector<unsigned int> fee_data[MAX_FEECOUNT];
   std::vector<intt_hit *> intt_hits;
   std::set<unsigned long long> BCO_List;
-  std::set<unsigned int> FEE_List;
+
+  // we make here a list of FEEs that we found associated with a given BCO
+  std::map<unsigned long long, std::set<unsigned int>> FEE_BCO_Association;
+  //  std::set<unsigned int> FEE_List;
 
 };
 


### PR DESCRIPTION
ddump now lists

>Packet  3001   324 -1 (sPHENIX Packet) 110 (IDINTTV0)
> Number of unique BCOs: 2
> BCO   0:  0x19f842a0b7    number of FEEs for this BCO  14
>           Number of unique FEEs:    0   1   2   3   4   5   6   7   8  9  10  11  12  13
> BCO   1:  0x19f842a357    number of FEEs for this BCO   7
>           Number of unique FEEs:    0   3   4   5   7   8  13
> Number of hits: 190
>      FEE    BCO      chip_BCO  chip_id channel_id    ADC  full_phx
>      full_ROC Ampl.
>   0     0  19f842a0b7   0x1f       2        80         0     0 0       0     0x0150001f
>   1     0  19f842a0b7   0x1f       2        86         0     0 0       0     0x0156001f
>...