### PR TITLE
CD: Added a clear to MVTX lanes w/ decoding errors

### DIFF
--- a/newbasic/oncsSub_idmvtxv3.cc
+++ b/newbasic/oncsSub_idmvtxv3.cc
@@ -62,7 +62,11 @@ int oncsSub_idmvtxv3::decode()
   for (auto& link : mGBTLinks)
   {
     mvtx::GBTLink::CollectedDataStatus decoding_status = link.collectROFCableData();
-    if(decoding_status == mvtx::GBTLink::CollectedDataStatus::AbortedOnError) m_decoding_failed = true;
+    if(decoding_status == mvtx::GBTLink::CollectedDataStatus::AbortedOnError)
+    {
+      m_decoding_failed = true;
+      link.clearCableData();
+    }
   }
 
   ++mEventId;


### PR DESCRIPTION
At Jakubs suggestion, a clear was added to any MVTX lanes that see a decoding error. This is hard to test that it solves our memory issue without first deploying it to find a decoding error