### PR TITLE
Tpcspeedup 2

### DIFF
--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -323,11 +323,8 @@ int oncsSub_idtpcfeev4::tpc_decode ()
 	}
     }
 
-  auto it = waveforms.begin();
-  for ( ; it != waveforms.end(); ++it)
-    {
-      waveform_vector.push_back( *it);
-    }
+  waveform_vector.resize(waveforms.size());
+  std::copy(waveforms.begin(),waveforms.end(),waveform_vector.begin());
   waveforms.clear();
   
   return 0;

--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -10,10 +10,7 @@ using namespace std;
 
 oncsSub_idtpcfeev4::oncsSub_idtpcfeev4(subevtdata_ptr data)
   :oncsSubevent_w2 (data)
-{
- _last_requested_element = -1;  // impossible value to mark "unnused" 
- _last_requested_waveform = 0;
-}
+{}
 
 
 oncsSub_idtpcfeev4::~oncsSub_idtpcfeev4()
@@ -192,8 +189,9 @@ int oncsSub_idtpcfeev4::tpc_decode ()
           fee_data[fee_id].push_back(buffer[index++]);
         }
       }
-    } else if ((buffer[index] & 0xFF00) == GTM_MAGIC_KEY)
-{
+    }
+    else if ((buffer[index] & 0xFF00) == GTM_MAGIC_KEY)
+    {
       index += 16; // decoded in tpc_gtm_decode()
     }
     else
@@ -578,7 +576,7 @@ int oncsSub_idtpcfeev4::find_header ( const unsigned int yy,  const std::vector<
 {
   bool found = false;
   unsigned int pos = yy;
-  std::vector<unsigned short> header_candidate;
+  std::vector<unsigned short> header_candidate(HEADER_LENGTH);
 
   // we slide over the data and find the header, if any.
   // we calculate and return the amount of words we need to skip to find the vector.
@@ -593,7 +591,7 @@ int oncsSub_idtpcfeev4::find_header ( const unsigned int yy,  const std::vector<
 	  return -1;
 	}
 
-      header_candidate.push_back(orig[pos]);
+      header_candidate[i] = orig[pos];
       pos++;
     }
   
@@ -612,9 +610,9 @@ int oncsSub_idtpcfeev4::find_header ( const unsigned int yy,  const std::vector<
         }
       skip_amount++;
       if ( pos >= orig.size())    // if we reached the end, no more header here
-	{
-	  return -1;
-	}
+      {
+	return -1;
+      }
 
       //   coutfl << " next value " << pos << "  " << hex << orig[pos]  << dec << endl;
       header_candidate.erase(header_candidate.begin());  // delete the vector 1st element

--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -104,7 +104,7 @@ int oncsSub_idtpcfeev4::decode_gtm_data(unsigned short dat[16])
     return 0;
 }
 
-int oncsSub_idtpcfeev4::tpc_gtm_decode ()
+int oncsSub_idtpcfeev4::tpc_gtm_decode()
 {
 
   if (_is_gtm_decoded ) return 0;
@@ -119,6 +119,7 @@ int oncsSub_idtpcfeev4::tpc_gtm_decode ()
   // demultiplexer
   while (index < payload_length)
   {
+    // this part is decoded in tpc_decode()
     // Length for the 256-bit wide Round Robin Multiplexer for the data stream
     const unsigned int datalength = 0xf;
 
@@ -191,15 +192,9 @@ int oncsSub_idtpcfeev4::tpc_decode ()
           fee_data[fee_id].push_back(buffer[index++]);
         }
       }
-    } else if ((buffer[index] & 0xFF00) == GTM_MAGIC_KEY) {
-        unsigned short buf[16];
-
-        // memcpy?
-        for (unsigned int i = 0; i < 16; i++) {
-            buf[i] = buffer[index++];
-        }
-
-        decode_gtm_data(buf);
+    } else if ((buffer[index] & 0xFF00) == GTM_MAGIC_KEY)
+{
+      index += 16; // decoded in tpc_gtm_decode()
     }
     else
     {

--- a/newbasic/oncsSub_idtpcfeev4.h
+++ b/newbasic/oncsSub_idtpcfeev4.h
@@ -29,7 +29,8 @@ public:
 
 
 protected:
-  int tpc_decode ();
+  int tpc_decode();
+  int tpc_gtm_decode();
 
   static const unsigned short  MAGIC_KEY_0 = 0xfe;
 //  static const unsigned short  MAGIC_KEY_1 = 0x00;
@@ -56,7 +57,8 @@ protected:
   
   int _broken;
   
-  int _is_decoded;
+  int _is_decoded{0};
+  int _is_gtm_decoded{0};
 
   struct sampa_waveform {
     unsigned short fee = std::numeric_limits<unsigned short>::max();

--- a/newbasic/oncsSub_idtpcfeev4.h
+++ b/newbasic/oncsSub_idtpcfeev4.h
@@ -32,20 +32,20 @@ protected:
   int tpc_decode();
   int tpc_gtm_decode();
 
-  static const unsigned short  MAGIC_KEY_0 = 0xfe;
+  static const unsigned short  MAGIC_KEY_0 {0xfe};
 //  static const unsigned short  MAGIC_KEY_1 = 0x00;
-  static const unsigned short  MAGIC_KEY_1 = 0xed;
+  static const unsigned short  MAGIC_KEY_1 {0xed};
 
-  static const unsigned short FEE_MAGIC_KEY = 0xba00;
-  static const unsigned short GTM_MAGIC_KEY = 0xbb00;
-  static const unsigned short GTM_LVL1_ACCEPT_MAGIC_KEY = 0xbbf0;
-  static const unsigned short GTM_ENDAT_MAGIC_KEY = 0xbbf1;
-  static const unsigned short GTM_MODEBIT_MAGIC_KEY = 0xbbf2;
+  static const unsigned short FEE_MAGIC_KEY {0xba00};
+  static const unsigned short GTM_MAGIC_KEY {0xbb00};
+  static const unsigned short GTM_LVL1_ACCEPT_MAGIC_KEY {0xbbf0};
+  static const unsigned short GTM_ENDAT_MAGIC_KEY {0xbbf1};
+  static const unsigned short GTM_MODEBIT_MAGIC_KEY {0xbbf2};
 
-  static const unsigned short  MAX_FEECOUNT = 26;   // that many FEEs
-  static const unsigned short  MAX_CHANNELS   = 8*32; // that many channels per FEE
+  static const unsigned short  MAX_FEECOUNT {26};   // that many FEEs
+  static const unsigned short  MAX_CHANNELS   {8*32}; // that many channels per FEE
 //  static const unsigned short  HEADER_LENGTH  = 5;
-  static const unsigned short  HEADER_LENGTH  = 7;
+  static const unsigned short  HEADER_LENGTH  {7};
   
   unsigned short reverseBits(const unsigned short x) const;
   unsigned short crc16(const unsigned int fee, const unsigned int index, const int  l) const;
@@ -61,20 +61,20 @@ protected:
   int _is_gtm_decoded{0};
 
   struct sampa_waveform {
-    unsigned short fee = std::numeric_limits<unsigned short>::max();
-    unsigned short pkt_length = std::numeric_limits<unsigned short>::max();
-    unsigned short channel = std::numeric_limits<unsigned short>::max();
-    unsigned short sampa_channel = std::numeric_limits<unsigned short>::max();
-    unsigned short sampa_address = std::numeric_limits<unsigned short>::max();
-    unsigned int bx_timestamp = 0;
+    unsigned short fee {std::numeric_limits<unsigned short>::max()};
+    unsigned short pkt_length {std::numeric_limits<unsigned short>::max()};
+    unsigned short channel {std::numeric_limits<unsigned short>::max()};
+    unsigned short sampa_channel {std::numeric_limits<unsigned short>::max()};
+    unsigned short sampa_address {std::numeric_limits<unsigned short>::max()};
+    unsigned int bx_timestamp {0};
     std::vector<unsigned short> waveform;
-    unsigned short adc_length = std::numeric_limits<unsigned short>::max();
-    unsigned short checksum = std::numeric_limits<unsigned short>::max();
-    unsigned short user_word = std::numeric_limits<unsigned short>::max();
-    unsigned short type = std::numeric_limits<unsigned short>::max();
-    unsigned short data_parity = std::numeric_limits<unsigned short>::max();
-    bool     valid = false;
-    bool     parity_valid = false;
+    unsigned short adc_length {std::numeric_limits<unsigned short>::max()};
+    unsigned short checksum {std::numeric_limits<unsigned short>::max()};
+    unsigned short user_word {std::numeric_limits<unsigned short>::max()};
+    unsigned short type {std::numeric_limits<unsigned short>::max()};
+    unsigned short data_parity {std::numeric_limits<unsigned short>::max()};
+    bool     valid {false};
+    bool     parity_valid {false};
   };
 
   struct gtm_payload {
@@ -114,8 +114,8 @@ struct bco_compare {
   
   int cacheIterator(const int n);
   
-  int _last_requested_element;
-  sampa_waveform* _last_requested_waveform;
+  int _last_requested_element {-1}; // impossible value to mark "unused"
+  sampa_waveform* _last_requested_waveform {nullptr};
   
   std::vector<unsigned short> fee_data[MAX_FEECOUNT];
 


### PR DESCRIPTION
Another x6 speedup for the bco search by decoding the gtm data separately and only do the waveform decoding if waveforms are requested