### PR TITLE
IPA function to get # of valid FEEs w/o accessing waveform info

### DIFF
--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -113,7 +113,6 @@ int oncsSub_idtpcfeev4::tpc_gtm_decode()
   unsigned int index = 0;
 
   unsigned short *buffer = ( unsigned short *)  &SubeventHdr->data;
-  //std::vector<bool> fee_seen(26, false);
   std::bitset<26> fee_seen;
 
 

--- a/newbasic/oncsSub_idtpcfeev4.cc
+++ b/newbasic/oncsSub_idtpcfeev4.cc
@@ -106,12 +106,16 @@ int oncsSub_idtpcfeev4::tpc_gtm_decode()
 
   if (_is_gtm_decoded ) return 0;
   _is_gtm_decoded = 1;
+  NR_VALIDFEE=0;
 
   unsigned int payload_length = 2 * (getLength() - SEVTHEADERLENGTH - getPadding() );
 
   unsigned int index = 0;
 
   unsigned short *buffer = ( unsigned short *)  &SubeventHdr->data;
+  //std::vector<bool> fee_seen(26, false);
+  std::bitset<26> fee_seen;
+
 
   // demultiplexer
   while (index < payload_length)
@@ -124,11 +128,15 @@ int oncsSub_idtpcfeev4::tpc_gtm_decode()
     {
 
       unsigned int fee_id = buffer[index] & 0xff;
+      if (!fee_seen[fee_id]) {
+        fee_seen[fee_id] = true;
+        NR_VALIDFEE++;
+      }
       // coutfl << " index = " << index << " fee_id = " << fee_id << " len = " << datalength << endl;
       ++index;
       if (fee_id < MAX_FEECOUNT)
       {
-	index += datalength;
+        index += datalength;
       }
       if (index >= payload_length) break;
     }
@@ -139,7 +147,7 @@ int oncsSub_idtpcfeev4::tpc_gtm_decode()
       // memcpy?
       for (unsigned int i = 0; i < 16; i++)
       {
-	buf[i] = buffer[index++];
+        buf[i] = buffer[index++];
       }
 
       decode_gtm_data(buf);
@@ -338,6 +346,12 @@ long long oncsSub_idtpcfeev4::lValue(const int n, const char *what)
   {
     return gtm_data.size();
   }
+  
+  else if ( strcmp(what,"NR_VALIDFEE") == 0 )
+  {
+    return NR_VALIDFEE;
+  }
+  
 
   else if (strcmp(what, "TAGGER_TYPE") == 0 )
   {

--- a/newbasic/oncsSub_idtpcfeev4.h
+++ b/newbasic/oncsSub_idtpcfeev4.h
@@ -4,6 +4,7 @@
 #include "oncsSubevent.h"
 #include <vector>
 #include <set>
+#include <bitset>
 #include <algorithm>
 #include <functional>
 #include <limits>
@@ -56,6 +57,7 @@ protected:
   int decode_gtm_data(unsigned short gtm[16]);
   
   int _broken;
+  unsigned long NR_VALIDFEE = 0;
   
   int _is_decoded{0};
   int _is_gtm_decoded{0};


### PR DESCRIPTION
This is a IPA function to get # of valid FEEs w/o accessing waveform info in a faster way. 
@pinkenburg let me know if this doesn't make sense with your merge from yesterday