### PR TITLE
mlp - fixed a bug in the CAEN1742 decoder

### DIFF
--- a/newbasic/oncsSub_idcaenv1742.cc
+++ b/newbasic/oncsSub_idcaenv1742.cc
@@ -1,6 +1,7 @@
 #include "oncsSub_idcaenv1742.h"
 #include <cstring>
 
+
 oncsSub_idcaenv1742::oncsSub_idcaenv1742(subevtdata_ptr data)
   :oncsSubevent_w4 (data)
 {
@@ -126,8 +127,8 @@ int *oncsSub_idcaenv1742::decode ( int *nwout)
 		  pos +=3;
 		}
 	    }
+	  group_offset += pos + 1;
 	}
-      group_offset += pos + 1;
     }
   *nwout = samples*8 *4;
 
@@ -306,7 +307,7 @@ void  oncsSub_idcaenv1742::dump ( OSTREAM& os )
 	  
 	  os << std::setw(4) << iValue(i,j) << " ";
 	}
-      os << " tr: " << iValue(i, "TR0") << std::endl;
+      os << " tr: " << std::setw(5) << iValue(i, "TR0") << " " << std::setw(5) << iValue(i, "TR1")<< std::endl;
     }
   
   os << std::endl;


### PR DESCRIPTION
fixed a bug in the CAEN1742 decoder that derailed the decoding if not all readout groups were enabled.
I also added both the TR0 and TR1 values to ddump instead of just TR0 - as we are moving to more elaborate triggering schemes in the line laser orbit, TR0 and TR1 are not longer usually the same. 