### PR TITLE
add subdir-objects to AUTOMAKE_OPTIONS

### DIFF
--- a/newbasic/Makefile.am
+++ b/newbasic/Makefile.am
@@ -1,4 +1,4 @@
-AUTOMAKE_OPTIONS = foreign
+AUTOMAKE_OPTIONS = foreign subdir-objects
 
 if VXWORKS
 include_HEADERS = oncsdefs.h \


### PR DESCRIPTION
This PR adds subdir-objects to the automake options to get rid of the subdir warning under Alma9. This option seems compatible with our SL7 automake, so it shouldn't change anything