### PR TITLE
implement lValue for packet_iddigitizerv2 clock,eventnr

### DIFF
--- a/newbasic/packet_iddigitizerv2.cc
+++ b/newbasic/packet_iddigitizerv2.cc
@@ -193,6 +193,21 @@ int Packet_iddigitizerv2::decode ()
   return 0;
 }
 
+long long Packet_iddigitizerv2::lValue(const int n, const char *what)
+{
+
+  decode();
+
+  if ( strcmp(what,"CLOCK") == 0 )
+  {
+    return (unsigned int) _clock;
+  }
+  if ( strcmp(what,"EVTNR") == 0 )
+  {
+    return _evtnr;
+  }
+  return 0;
+}
 
 int Packet_iddigitizerv2::iValue(const int sample, const int ch)
 {

--- a/newbasic/packet_iddigitizerv2.h
+++ b/newbasic/packet_iddigitizerv2.h
@@ -16,6 +16,7 @@ public:
 
   int    iValue(const int sample, const int ch);
   int    iValue(const int ,const char * what);
+  long long   lValue(const int ,const char * what);
   void  dump ( OSTREAM& os = COUT) ;
 
 


### PR DESCRIPTION
Using lValue to get the clock for these packets results in having a negative 64 bit long long once the clock counter exceeds 0x8000000 which then throws off any clock difference calculations. resulting in 0xFFFFFFFF8000000 instead of 0x8000000. The reason is that currently the iValue is returned which is an int which then turns the long long into a negative value