### PR TITLE
mlp - an ad-hoc fix to a race condition in the packet_iddigitizerv3.cc

### DIFF
--- a/newbasic/packet_iddigitizerv3.cc
+++ b/newbasic/packet_iddigitizerv3.cc
@@ -240,6 +240,12 @@ unsigned int Packet_iddigitizerv3::decode_FEM ( unsigned int *k, const int fem_n
 		  index++;
 		}
 	    }
+	  else
+	    {
+	      coutfl << "unknown case: word classifier " << hex << "0x" << word_classifier << " next word 0x" << (k[index+1] >> 28) << dec << endl;
+	      _broken = 2;
+	      return 0;
+	    }
 
 	  // just in case we get a zero-suppressed word, step the index_channel
 	  index_channel++;


### PR DESCRIPTION
an ad-hoc fix to a race condition in the packet_iddigitizerv3.cc decoder. In a certain fraction of events we get into an infinite loop here. For now I abort the decoding, but this deserves a closer look.