### PR TITLE
needs -Wno-nontrivial-memcall for clang 20

### DIFF
--- a/newbasic/configure.ac
+++ b/newbasic/configure.ac
@@ -64,7 +64,7 @@ fi
 
 case $CXX in
  clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option"
+   CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-nontrivial-memcall"
  ;;
 esac
 


### PR DESCRIPTION
small addition to the configure.ac to compile it with the new clang version (20.1.8)