### PR TITLE
add new allowed header word

### DIFF
--- a/newbasic/packet_iddigitizerv3.cc
+++ b/newbasic/packet_iddigitizerv3.cc
@@ -108,7 +108,7 @@ int Packet_iddigitizerv3::decode ()
   for (int fem_index = 5; fem_index < dlength ; )  // we hop from FEM to FEM here
     {
 
-      if ( k[fem_index] == 0xa000ffff)
+      if ( k[fem_index] == 0xa000ffff || k[fem_index] == 0xa000fffe)
 	{
 	  // coutfl << " FEM_ start at  " << fem_index << "   " << hex << k[fem_index] << dec  << endl;
 	  
@@ -152,7 +152,7 @@ unsigned int Packet_iddigitizerv3::decode_FEM ( unsigned int *k, const int fem_n
 
   
   // should have been checked but let's be sure
-  if ( k[0] != 0xa000ffff) return 0;
+  if ( k[0] != 0xa000ffff && k[0] != 0xa000fffe) return 0;
   
   _fem_slot[fem_nr]  = k[1] & 0xffff;
   _fem_evtnr[fem_nr] = k[2] & 0xffff;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Add New Allowed Header Word for FEM Decoder

## Status
**Draft** — Not ready for merge (author indicated "Draft -- do not merge!!")

## Motivation / Context
This PR modifies the digitizer packet decoder (used in sPHENIX's online event reconstruction) to recognize an additional valid Front-End Module (FEM) header marker value. The FEM decoder currently only accepts the header word `0xa000ffff` to demarcate FEM data blocks. This change extends support to also accept `0xa000fffe`, likely reflecting hardware revisions, operational modes, or detector configurations that produce this alternative marker value.

## Key Changes
- **Main decode loop (line 111)**: Updated FEM start detection to accept either `0xa000ffff` **or** `0xa000fffe` as valid FEM block markers
- **decode_FEM validation (line 155)**: Relaxed the initial header validation to accept both marker values instead of strictly requiring `0xa000ffff`
- **Minimal code footprint**: 2 lines added, 2 lines removed in `newbasic/packet_iddigitizerv3.cc`

## Potential Risk Areas
- **Data filtering impact**: Events containing the new marker value will now be accepted where they may have previously been rejected as malformed. This could alter event selection efficiency and require reprocessing of historical data
- **Reconstruction consistency**: Both marker paths flow through the same decoder logic, but if hardware producing the new marker behaves differently, downstream reconstruction algorithms may produce different results
- **Silent acceptance of corruption**: If `0xa000fffe` can also appear in corrupted packet data by chance, this change risks silently accepting malformed events
- **Backward compatibility**: Existing analysis cuts and validation procedures should be reviewed to ensure they remain appropriate

## Possible Future Improvements
- Document which detector hardware revisions/configurations produce each marker value
- Add decoder diagnostics or histograms to track frequency of each marker type
- Include unit tests verifying both markers decode identically for the same FEM data
- Consider whether additional marker values may exist and require similar support
- Add optional configuration flag to selectively enable/disable the new marker for debugging

## Note on AI Analysis
The above summary is AI-generated and may contain inaccuracies. Please validate detector hardware specifications, operational notes, and any related detector physics/operations meetings before proceeding with merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->